### PR TITLE
Migration of various features from the v2 repo

### DIFF
--- a/onmt/inputters/dataset.py
+++ b/onmt/inputters/dataset.py
@@ -47,14 +47,12 @@ def read_examples_from_files(
         }
 
     if src_path.endswith('.gz'):
-        logger.info(f'Detected source GZ: {src_path}')
         src_fh = gzip.open(src_path, 'rt')
     else:
         src_fh = open(src_path, 'rt')
     if tgt_path is None:
         tgt_fh = itertools.repeat(None)
     elif tgt_path.endswith('.gz'):
-        logger.info(f'Detected target GZ: {tgt_path}')
         tgt_fh = gzip.open(tgt_path, 'rt')
     else:
         tgt_fh = open(tgt_path, 'rt')

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Training on a single process."""
 import torch
+import time
 
 from onmt.model_builder import build_model
 from onmt.utils.optimizers import Optimizer
@@ -130,6 +131,9 @@ def main(
 
     init_logger(opt.log_file, gpu_id=device_context.id)
     if device_context.is_distributed():
+        sleep_s = device_context.local_rank * 2
+        logger.warning(f'sleeping {sleep_s}s to alleviate ROCm deadlock')
+        time.sleep(sleep_s)
         configure_process(opt, device_context.local_rank)
         gpu_rank_t = torch.distributed.get_rank()
         logger.info("RANK GPU FROM TORCH %s", str(gpu_rank_t))

--- a/onmt/transforms/misc.py
+++ b/onmt/transforms/misc.py
@@ -39,7 +39,6 @@ class FilterTooLongTransform(Transform):
         tgt_len = len(example['tgt'])
         if src_len == 0 or tgt_len == 0:
             # also filter empty strings
-            logger.warning(f'Empty string, src_len {src_len} tgt_len {tgt_len}')
             return None
         if src_len > self.src_seq_length or tgt_len > self.tgt_seq_length:
             if stats is not None:

--- a/onmt/transforms/misc.py
+++ b/onmt/transforms/misc.py
@@ -35,7 +35,13 @@ class FilterTooLongTransform(Transform):
 
     def apply(self, example, is_train=False, stats=None, **kwargs):
         """Return None if too long else return as is."""
-        if len(example['src']) > self.src_seq_length or len(example['tgt']) > self.tgt_seq_length:
+        src_len = len(example['src'])
+        tgt_len = len(example['tgt'])
+        if src_len == 0 or tgt_len == 0:
+            # also filter empty strings
+            logger.warning(f'Empty string, src_len {src_len} tgt_len {tgt_len}')
+            return None
+        if src_len > self.src_seq_length or tgt_len > self.tgt_seq_length:
             if stats is not None:
                 stats.update(FilterTooLongStats())
             return None


### PR DESCRIPTION
**Remove the logging for .gz files**
The feature confirmed to work, so logging is no longer necessary. When using very tiny data sets e.g. for smoke testing, this results in log spam, because the same file is opened and read repeatedly to initialize the length binning.

**Filter out empty strings**
The maximum length filter now also removes empty strings. This allows using uncleaned corpora without having sentencepiece blow up.

**Alleviate ROCm deadlock**
ROCm init dot not handle multiprocessing well: each process tries to acquire the same lock with a fairly short timeout. This can lead to crashes when a multi-gpu node is initializing. Adding a sleep dependent on the local rank alleviates the problem.