### PR TITLE
Log the end of training into the structured log file

### DIFF
--- a/mammoth/distributed/contexts.py
+++ b/mammoth/distributed/contexts.py
@@ -29,13 +29,6 @@ class WorldContext:
         """Data tensors must be moved to the GPU for compute"""
         return self.context != DeviceContextEnum.CPU
 
-    def is_master(self):
-        """For code that should only run in one process:
-        - saving fully shared modules from one device only
-        - avoiding log spam when all devices would log the same result
-        """
-        return not self.is_distributed() or self.global_rank == 0
-
     def global_to_local(self, node_rank, local_rank):
         assert node_rank is not None
         assert local_rank is not None
@@ -93,6 +86,13 @@ class DeviceContext(WorldContext):
             return f'GPU {self.node_rank}:{self.local_rank}'
         else:
             return 'CPU'
+
+    def is_master(self):
+        """For code that should only run in one process:
+        - saving fully shared modules from one device only
+        - avoiding log spam when all devices would log the same result
+        """
+        return not self.is_distributed() or self.global_rank == 0
 
     def validate(self, world_context):
         # check that this DeviceContext is consistent with given WorldContext

--- a/mammoth/trainer.py
+++ b/mammoth/trainer.py
@@ -395,7 +395,7 @@ class Trainer(object):
 
         if self.model_saver is not None:
             self.model_saver.save(step, moving_average=self.moving_average)
-        if self.report_manager is not None:
+        if device_context.is_master() and self.report_manager is not None:
             self.report_manager.report_end(step)
         return total_stats
 

--- a/mammoth/trainer.py
+++ b/mammoth/trainer.py
@@ -395,6 +395,7 @@ class Trainer(object):
 
         if self.model_saver is not None:
             self.model_saver.save(step, moving_average=self.moving_average)
+        self.report_manager.report_end(step)
         return total_stats
 
     def validate(self, valid_iter, moving_average=None, task=None):

--- a/mammoth/trainer.py
+++ b/mammoth/trainer.py
@@ -395,7 +395,8 @@ class Trainer(object):
 
         if self.model_saver is not None:
             self.model_saver.save(step, moving_average=self.moving_average)
-        self.report_manager.report_end(step)
+        if self.report_manager is not None:
+            self.report_manager.report_end(step)
         return total_stats
 
     def validate(self, valid_iter, moving_average=None, task=None):

--- a/mammoth/utils/report_manager.py
+++ b/mammoth/utils/report_manager.py
@@ -99,6 +99,17 @@ class ReportMgrBase(object):
     def _report_step(self, *args, **kwargs):
         raise NotImplementedError()
 
+    def _report_end(self, step):
+        raise NotImplementedError()
+
+    def report_end(self, step):
+        if self.start_time < 0:
+            raise ValueError(
+                """ReportMgr needs to be started
+                                (set 'start_time' or use 'start()'"""
+            )
+        self._report_end(step)
+
 
 class ReportMgr(ReportMgrBase):
     def __init__(self, report_every, start_time=-1.0, tensorboard_writer=None):
@@ -153,3 +164,15 @@ class ReportMgr(ReportMgrBase):
                 'crossentropy': valid_stats.xent(),
             })
             self.maybe_log_tensorboard(valid_stats, "valid", lr, patience, step)
+
+    def _report_end(self, step):
+        end_time = time.time()
+        duration_s = end_time - self.start_time
+        self.log('Training ended. Duration %g s', duration_s)
+        structured_logging({
+            'type': 'end',
+            'step': step,
+            'start_time': self.start_time,
+            'end_time': end_time,
+            'duration_s': duration_s,
+        })


### PR DESCRIPTION
Log the end of training into the structured log file

This allows HPO to detect that training has ended.

The format looks like this:
{"type": "end", "step": 20, "start_time": 1698044256.6410203, "end_time": 1698044361.484478, "duration_s": 104.84345769882202}

Note that currently only a successful end of training is detected: if
the training is killed, e.g. because of a slurm timeout, nothing is
written into the structured log file. If we want to handle these as well
(and we do need to, unless we manage to set the number of training steps
perfectly), we need a signal handler to listen for the signals sent by
slurm. Normally this is SIGTERM sent when the time limit is exceeded,
but it is possible to use the --signal parameter to send other signals
in advance of the time limit. Note that we already have a signal handler
in mammoth.distributed.communication.ErrorHandler

Closes #34
