### PR TITLE
unify translation config

### DIFF
--- a/mammoth/distributed/tasks.py
+++ b/mammoth/distributed/tasks.py
@@ -5,7 +5,7 @@ from collections import OrderedDict, namedtuple, Counter
 from dataclasses import dataclass
 from itertools import cycle, islice
 from pprint import pformat
-from typing import Any, Optional, List
+from typing import Any, Optional, List, Tuple
 
 import numpy as np
 import torch
@@ -138,8 +138,8 @@ class TaskSpecs():
     corpus_opts: dict
     src_vocab: Any  # FIXME: type
     tgt_vocab: Any
-    encoder_adapter_ids: List[str]
-    decoder_adapter_ids: List[str]
+    encoder_adapter_ids: List[Tuple[int, str, str]]
+    decoder_adapter_ids: List[Tuple[int, str, str]]
 
     def get_serializable_metadata(self):
         """

--- a/mammoth/modules/layer_stack_decoder.py
+++ b/mammoth/modules/layer_stack_decoder.py
@@ -57,39 +57,38 @@ class LayerStackDecoder(DecoderBase):
         return cls(embeddings, decoders)
 
     @classmethod
-    def from_trans_opt(cls, model_opts, embeddings, opt_stack):
-        """Alternate constructor for use during translation."""
+    def from_trans_opt(cls, opts, embeddings, task, is_on_top=False):
+        """Alternate constructor for use during training."""
         decoders = nn.ModuleList()
-        for layer_stack_index, n_layers in enumerate(model_opts.dec_layers):
+        for layer_stack_index, n_layers in enumerate(opts.dec_layers):
+            is_on_top = layer_stack_index == len(opts.dec_layers) - 1
             stacks = nn.ModuleDict()
-            is_on_top = layer_stack_index == len(model_opts.dec_layers) - 1
-            module_opts = opt_stack['decoder'][layer_stack_index]
-            module_id = module_opts['id']
+            module_id = task.decoder_id[layer_stack_index]
             stacks[module_id] = AdaptedTransformerDecoder(
                 n_layers,
-                model_opts.model_dim,
-                model_opts.heads,
-                model_opts.transformer_ff,
-                model_opts.copy_attn,
-                model_opts.self_attn_type,
-                model_opts.dropout[0] if type(model_opts.dropout) is list else model_opts.dropout,
+                opts.model_dim,
+                opts.heads,
+                opts.transformer_ff,
+                opts.copy_attn,
+                opts.self_attn_type,
+                opts.dropout[0] if type(opts.dropout) is list else opts.dropout,
                 (
-                    model_opts.attention_dropout[0]
-                    if type(model_opts.attention_dropout) is list
-                    else model_opts.attention_dropout
+                    opts.attention_dropout[0]
+                    if type(opts.attention_dropout) is list
+                    else opts.attention_dropout
                 ),
                 None,  # embeddings,
-                model_opts.max_relative_positions,
-                model_opts.aan_useffn,
-                model_opts.full_context_alignment,
-                model_opts.alignment_layer,
-                alignment_heads=model_opts.alignment_heads,
-                pos_ffn_activation_fn=model_opts.pos_ffn_activation_fn,
+                opts.max_relative_positions,
+                opts.aan_useffn,
+                opts.full_context_alignment,
+                opts.alignment_layer,
+                alignment_heads=opts.alignment_heads,
+                pos_ffn_activation_fn=opts.pos_ffn_activation_fn,
                 layer_norm_module=(
-                    nn.LayerNorm(model_opts.model_dim, eps=1e-6) if is_on_top
+                    nn.LayerNorm(opts.model_dim, eps=1e-6) if is_on_top
                     else nn.Identity()
                 ),
-                is_normformer=model_opts.normformer,
+                is_normformer=opts.normformer,
             )
             decoders.append(stacks)
         return cls(embeddings, decoders)

--- a/mammoth/modules/layer_stack_encoder.py
+++ b/mammoth/modules/layer_stack_encoder.py
@@ -51,33 +51,32 @@ class LayerStackEncoder(EncoderBase):
         return cls(embeddings, encoders)
 
     @classmethod
-    def from_trans_opt(cls, model_opts, embeddings, opt_stack):
-        """Alternate constructor for use during translation."""
+    def from_trans_opt(cls, opts, embeddings, task):
+        """Alternate constructor for use during training."""
         encoders = nn.ModuleList()
-        for layer_stack_index, n_layers in enumerate(model_opts.enc_layers):
+        for layer_stack_index, n_layers in enumerate(opts.enc_layers):
             stacks = nn.ModuleDict()
-            module_opts = opt_stack['encoder'][layer_stack_index]
-            module_id = module_opts['id']
-            is_on_top = layer_stack_index == len(model_opts.enc_layers) - 1
+            is_on_top = layer_stack_index == len(opts.enc_layers) - 1
+            module_id = task.encoder_id[layer_stack_index]
             stacks[module_id] = AdaptedTransformerEncoder(
                 n_layers,
-                model_opts.model_dim,
-                model_opts.heads,
-                model_opts.transformer_ff,
-                model_opts.dropout[0] if type(model_opts.dropout) is list else model_opts.dropout,
+                opts.model_dim,
+                opts.heads,
+                opts.transformer_ff,
+                opts.dropout[0] if type(opts.dropout) is list else opts.dropout,
                 (
-                    model_opts.attention_dropout[0]
-                    if type(model_opts.attention_dropout) is list
-                    else model_opts.attention_dropout
+                    opts.attention_dropout[0]
+                    if type(opts.attention_dropout) is list
+                    else opts.attention_dropout
                 ),
                 None,  # embeddings,
-                model_opts.max_relative_positions,
-                pos_ffn_activation_fn=model_opts.pos_ffn_activation_fn,
+                opts.max_relative_positions,
+                pos_ffn_activation_fn=opts.pos_ffn_activation_fn,
                 layer_norm_module=(
-                    nn.LayerNorm(model_opts.model_dim, eps=1e-6) if is_on_top
+                    nn.LayerNorm(opts.model_dim, eps=1e-6) if is_on_top
                     else nn.Identity()
                 ),
-                is_normformer=model_opts.normformer,
+                is_normformer=opts.normformer,
             )
             encoders.append(stacks)
         return cls(embeddings, encoders)

--- a/mammoth/opts.py
+++ b/mammoth/opts.py
@@ -1185,13 +1185,10 @@ def translate_opts(parser, dynamic=False):
         "Necessary for models whose output layers can assign "
         "zero probability.",
     )
-    group.add('--lang_pair', '-lang_pair', help="language pair to translate")
+    group.add('--task_id', '-task_id', help="Task id to determine components to load for translation")
 
     group = parser.add_argument_group('Data')
     group.add('--data_type', '-data_type', default="text", help="Type of the source input. Options: [text].")
-
-    #    group.add('--lang_pair', '-lang_pair',
-    #              help="language pair to translate")
 
     group.add('--src', '-src', required=True, help="Source sequence to decode (one line per sequence)")
     group.add(
@@ -1241,53 +1238,6 @@ def translate_opts(parser, dynamic=False):
     )
     group.add('--gpu', '-gpu', type=int, default=-1, help="Device to run on")
 
-    if dynamic:
-        group.add(
-            "-transforms",
-            "--transforms",
-            default=[],
-            nargs="+",
-            choices=AVAILABLE_TRANSFORMS.keys(),
-            help="Default transform pipeline to apply to data.",
-        )
-
-        # Adding options related to Transforms
-        _add_dynamic_transform_opts(parser)
-
-        group.add(
-            "--src_prefix",
-            "-src_prefix",
-            default="",
-            help="The encoder prefix, i.e. language selector token",
-        )
-        group.add(
-            "--tgt_prefix",
-            "-tgt_prefix",
-            default="",
-            help="The decoder prefix (FIXME: does not work, but must be set nevertheless)",
-        )
-
-
-def build_bilingual_model(parser):
-    """options for modular translation"""
-    group = parser.add_argument_group("Source and Target Languages")
-    group.add(
-        "--src_lang",
-        "-src_lang",
-        required=True,
-        help="The 2-character source language code",
-    )
-    group.add(
-        "--tgt_lang",
-        "-tgt_lang",
-        required=True,
-        help="The 2-character target language code",
-    )
-    group.add(
-        "--stack",
-        required=True,
-        help="The stack of modules to use. Use a yaml conf, for your own sanity"
-    )
     group.add(
         "--output_model",
         "-output_model",

--- a/mammoth/translate/translator.py
+++ b/mammoth/translate/translator.py
@@ -35,7 +35,7 @@ def build_translator(opts, task, report_score=True, logger=None, out_file=None):
     )
     if logger:
         logger.info(str(task))
-    vocabs, model, model_opts = load_test_model(opts)
+    vocabs, model, model_opts = load_test_model(opts, task)
 
     scorer = mammoth.translate.GNMTGlobalScorer.from_opts(opts)
 
@@ -290,7 +290,7 @@ class Inference(object):
             ignore_when_blocking=set(opts.ignore_when_blocking),
             replace_unk=opts.replace_unk,
             ban_unk_token=opts.ban_unk_token,
-            tgt_prefix=opts.tgt_prefix,
+            tgt_prefix=task.corpus_opts['tgt_prefix'],
             phrase_table=opts.phrase_table,
             data_type=opts.data_type,
             verbose=opts.verbose,


### PR DESCRIPTION
Ding dong, the translation config is dead.

- There is no longer a separate translation config with different structure.
 - When translating, a task must be specified. It can either be one of
      the supervised tasks used during training, or a zero-shot task added
      later.
- Translation accepts arbitrary arguments, ignoring invalid arguments
      silently. This allows using the training config, even though many of
      the arguments have no function during translation.
- There is currently no way to automatically generate zero-shot configs.
    Currently it must be done by hand: copypasting and editing a supervised
    task definition.