### PR TITLE
gpu assignment scaling

### DIFF
--- a/tools/benchmark_gpu_assignment.py
+++ b/tools/benchmark_gpu_assignment.py
@@ -74,7 +74,7 @@ def dummy_config(langs, tasks, architecture, n_gpus_per_node, n_slots_per_gpu):
         'dec_layers': [6],
     }
     return config
-    
+
 
 @click.command()
 @click.option('--n_langs', type=int, required=True)

--- a/tools/benchmark_gpu_assignment.py
+++ b/tools/benchmark_gpu_assignment.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+import click
+import random
+import yaml
+from itertools import product
+
+def create_langs(n_langs):
+    langs = ['centric']
+    langs.extend(["lang{:05d}".format(i) for i in range(2, n_langs + 1)])
+    return langs
+
+def centric_pairs(langs):
+    result = []
+    non_centric = [lang for lang in langs if lang != 'centric']
+    for other in non_centric:
+        result.append(('centric', other))
+        result.append((other, 'centric'))
+    result.append(('centric', 'centric'))
+    return result
+
+def complete_language_pairs(langs, sparsity):
+    if sparsity == 'multiparallel':
+        return list(product(langs, langs))
+    pairs = centric_pairs(langs)
+    if sparsity == 'centric':
+        return pairs
+
+def create_tasks(lang_pairs, curriculum):
+    tasks = dict()
+    if curriculum:
+        tmp = list(lang_pairs)
+        random.shuffle(tmp)
+        half = len(tmp) // 2
+        not_ready = set(tmp[:half])
+    else:
+        not_ready = set()
+    for src_lang, tgt_lang in lang_pairs:
+        tasks[f'train_{src_lang}_{tgt_lang}'] = {
+            'src_tgt': f'{src_lang}-{tgt_lang}',
+            'introduce_at_training_step': 1000 if (src_lang, tgt_lang) in not_ready else 0,
+        }
+    return tasks
+
+def dummy_config(langs, tasks, architecture, n_gpus_per_node, n_slots_per_gpu):
+    groups = {lang: 'all' for lang in langs}
+    if architecture == 'full/langspec':
+        enc_layers = [6]
+        enc_sharing_groups = ['FULL']
+        dec_sharing_groups = ['TGT_LANGUAGE']
+    elif architecture == 'langspec/langspec':
+        enc_layers = [6]
+        enc_sharing_groups = ['SRC_LANGUAGE']
+        dec_sharing_groups = ['TGT_LANGUAGE']
+    elif architecture == 'apple':
+        enc_layers = [2, 2, 2]
+        enc_sharing_groups = ['SRC_LANGUAGE', 'FULL', 'TGT_LANGUAGE']
+        dec_sharing_groups = ['TGT_LANGUAGE']
+    config = {
+        'config_config': {
+            'groups': groups,
+            'enc_sharing_groups': enc_sharing_groups,
+            'dec_sharing_groups': dec_sharing_groups,
+            # 'n_nodes'
+            'n_gpus_per_node': n_gpus_per_node,
+            'n_slots_per_gpu': n_slots_per_gpu,
+        },
+        'tasks': tasks,
+        'enc_layers': enc_layers,
+        'dec_layers': [6],
+    }
+    return config
+    
+
+@click.command()
+@click.option('--n_langs', type=int, required=True)
+@click.option('--sparsity', type=click.Choice(['multiparallel', 'centric', 'semi-centric']), required=True)
+@click.option('--architecture', type=click.Choice(['full/langspec', 'langspec/langspec', 'apple']), required=True)
+@click.option('--curriculum', is_flag=True)
+@click.option('--n_gpus_per_node', type=int, default=8)
+@click.option('--n_slots_per_gpu', type=int, required=True)
+def main(n_langs, sparsity, architecture, curriculum, n_gpus_per_node, n_slots_per_gpu):
+    name = f'n_langs={n_langs}_sparsity={sparsity}_architecture={architecture}_curriculum={curriculum}_n_gpus_per_node={n_gpus_per_node}_n_slots_per_gpu={n_slots_per_gpu}'
+    name = name.replace('/', '+')
+    langs = create_langs(n_langs)
+    lang_pairs = sorted(complete_language_pairs(langs, sparsity))
+    tasks = create_tasks(lang_pairs, curriculum)
+    config = dummy_config(langs, tasks, architecture, n_gpus_per_node, n_slots_per_gpu)
+    filename = f'{name}.init.yaml'
+    with open(filename, 'w') as fout:
+        print(f'writing into {filename}')
+        yaml.safe_dump(config, fout)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/config_config.py
+++ b/tools/config_config.py
@@ -166,6 +166,7 @@ def add_allocate_device_args(parser):
     parser.add_argument('--n_nodes', type=int)
     parser.add_argument('--n_gpus_per_node', type=int)
     parser.add_argument('--n_slots_per_gpu', type=int)
+    parser.add_argument('--log_name', type=str)
 
 
 def add_set_transforms_args(parser):
@@ -512,6 +513,7 @@ def allocate_devices(opts):
         lang_pairs=lang_pairs,
         lang_to_group_mapping=cc_opts['groups'],
         lps_ready_to_start=lps_ready_to_start,
+        log_name=opts.log_name,
     )
 
     for gpu_slot, lp in assignment.items():

--- a/tools/config_config.py
+++ b/tools/config_config.py
@@ -826,7 +826,8 @@ def extra_cpu(opts):
     del opts.in_config[0]['world_size']
     opts.in_config[0]['n_nodes'] = 1
     for task_opts in opts.in_config[0]['tasks'].values():
-        del task_opts['node_gpu']
+        if 'node_gpu' in task_opts:
+            del task_opts['node_gpu']
 
 
 def extra_fully_shared_hack(opts):

--- a/tools/config_config.py
+++ b/tools/config_config.py
@@ -167,6 +167,10 @@ def add_allocate_device_args(parser):
     parser.add_argument('--n_gpus_per_node', type=int)
     parser.add_argument('--n_slots_per_gpu', type=int)
     parser.add_argument('--log_name', type=str)
+    parser.add_argument(
+        '--time_budget_s', type=int,
+        help='time budget for GPU assignment, in seconds',
+    )
 
 
 def add_set_transforms_args(parser):
@@ -533,6 +537,7 @@ def allocate_devices(opts):
         lang_to_group_mapping=cc_opts['groups'],
         lps_ready_to_start=lps_ready_to_start,
         log_name=opts.log_name,
+        time_budget_s=opts.time_budget_s,
     )
 
     for gpu_slot, lp in assignment.items():

--- a/tools/gpu_assignment.py
+++ b/tools/gpu_assignment.py
@@ -346,7 +346,7 @@ class AssignmentOptimizer:
     def best_swap_for(self, slot_a: GpuSlot, assignment, current_cost, slot_subset=None):
         slot_subset = self.gpu_slots if slot_subset is None else slot_subset
         costs = [(current_cost, slot_a)]
-        for i, slot_b in enumerate(tqdm(slot_subset, desc='best_swap_for', leave=False)):
+        for i, slot_b in enumerate(slot_subset):
             if slot_a.node == slot_b.node and slot_a.gpu == slot_b.gpu:
                 # No point swapping pairs already on the same device
                 continue

--- a/tools/gpu_assignment.py
+++ b/tools/gpu_assignment.py
@@ -246,9 +246,10 @@ class AssignmentOptimizer:
             else:
                 # also populate gpus with zero count
                 filled[gpu] += 0
+        n_empty = sum(1 for x in filled.values() if x == 0)
         min_filled = min(filled.values())
         max_filled = max(filled.values())
-        penalty = extra_empty_penalty if min_filled == 0 else 0
+        penalty = n_empty * extra_empty_penalty
         if filled[(0, 0)] > min_filled:
             # There are unassigned slots, but more of them on some other device than master (0:0)
             # Master has some extra duties, so it is the optimal place for empty slots
@@ -355,7 +356,7 @@ def optimize_gpu_assignment(
     if log_name:
         with open('gpu_assignment_cost_log.jsonl', 'a') as fout:
             record = {
-                'method': 'original',
+                'method': 'empty_penalty',
                 'name': log_name,
                 'n_nodes': n_nodes,
                 'n_gpus_per_node': n_gpus_per_node,


### PR DESCRIPTION
- Instead of considering all swaps of all gpu slots, make some educated guesses interleaved with random subsetting
- Parameter `--time_budget_s` allows setting a fixed time budget for the GPU assignment
- Fix a bug in the extra_empty_penalty: apply extra_empty_penalty for each empty GPU
    
    If the heuristic only penalizes for the existence of empty GPUs, then
    reducing the number of empty GPUs by one will not be visible in the loss
    unless it is the last one. The penalty should be applied for each empty
    GPU individually.

- Some misc improvements to config-config, e.g. use tqdm for progress indicator instead of spewing garbage all over stdout.