### PR TITLE
data state restoration

### DIFF
--- a/mammoth/bin/train.py
+++ b/mammoth/bin/train.py
@@ -80,8 +80,8 @@ def _init_train(opts):
             if len(old_transf) != 0:
                 _msg += f" -{old_transf}."
             logger.warning(_msg)
-        if opts.update_vocab:
-            logger.info("Updating checkpoint vocabulary with new vocabulary")
+        # if opts.update_vocab:
+        #    logger.info("Updating checkpoint vocabulary with new vocabulary")
             # fields, transforms_cls = prepare_fields_transforms(opts)
     else:
         checkpoint = None

--- a/mammoth/bin/train.py
+++ b/mammoth/bin/train.py
@@ -272,12 +272,16 @@ def train(opts):
             opts=opts
         )
         # Get the iterator to generate from
+        line_idx_restore = None
+        if checkpoint is not None:
+            line_idx_restore = checkpoint['data_state']
         train_iter = DynamicDatasetIter.from_opts(
             task_queue_manager=task_queue_manager,
             transforms_cls=transforms_cls,
             vocabs_dict=vocabs_dict,
             opts=opts,
             is_train=True,
+            line_idx_restore=line_idx_restore,
         )
 
         producer = mp.Process(

--- a/mammoth/inputters/dataloader.py
+++ b/mammoth/inputters/dataloader.py
@@ -53,10 +53,10 @@ class InferenceBatcher():
         for example in iter(self.examples_stream):
             accum.append(example)
             if len(accum) >= self.batch_size:
-                yield self.collate_fn(accum)
+                yield self.collate_fn(accum, 0)
                 accum = []
         if accum:
-            yield self.collate_fn(accum)
+            yield self.collate_fn(accum, 0)
 
 
 class ScoredInfiniteExamples():
@@ -153,7 +153,8 @@ class SimpleLookAheadBucketing():
                     [
                         example_dict for _, example_dict
                         in itertools.islice(maxi_batch_it, epb)
-                    ]
+                    ],
+                    self._sie._current_line_idx,
                 )
 
 
@@ -175,7 +176,7 @@ class SentenceMinibatcher():
             for _ in range(self.batch_size):
                 _, example = self._sie.next()
                 minibatch.append(example)
-            yield self.collate_fn(accum, self._sie._current_line_idx)
+            yield self.collate_fn(minibatch, self._sie._current_line_idx)
 
 
 class DynamicDatasetIter(object):

--- a/mammoth/inputters/dataloader.py
+++ b/mammoth/inputters/dataloader.py
@@ -228,6 +228,8 @@ class DynamicDatasetIter(object):
         self.batch_size = batch_size
         self.batch_size_multiple = batch_size_multiple
         self.device = 'cpu'
+        self.max_look_ahead_sentences = max_look_ahead_sentences
+        self.lookahead_minibatches = lookahead_minibatches
         self.line_idx_restore = dict() if line_idx_restore is None else line_idx_restore
 
     @classmethod

--- a/mammoth/inputters/dataloader.py
+++ b/mammoth/inputters/dataloader.py
@@ -53,6 +53,7 @@ class InferenceBatcher():
         for example in iter(self.examples_stream):
             accum.append(example)
             if len(accum) >= self.batch_size:
+                # line idx == 0 during inference
                 yield self.collate_fn(accum, 0)
                 accum = []
         if accum:
@@ -66,7 +67,7 @@ class ScoredInfiniteExamples():
         self._it = iter(self.dataset)
         self._prev = next(self._it)
         self._score = self.score_fn(self._prev)
-        self._current_line_idx = None
+        self._current_line_idx = self._prev['line_idx']
 
     def peek_at_score(self):
         return self._score
@@ -80,6 +81,7 @@ class ScoredInfiniteExamples():
         score_out, example_out = self._score, self._prev
         self._score = self.score_fn(example)
         self._prev = example
+        self._current_line_idx = self._prev['line_idx']
         return score_out, example_out
 
 

--- a/mammoth/inputters/dataset.py
+++ b/mammoth/inputters/dataset.py
@@ -116,8 +116,11 @@ class ParallelCorpus(IterableDataset):
         """Split string, accompanied by a drumroll"""
         return string.split()
 
-    def _numericalize(self, tokens, side='src'):
+    def _maybe_numericalize(self, key, value):
         """Convert list of strings into list of indices"""
+        if key not in ('src', 'tgt'):
+            return value
+        tokens, side = value, key
         vocab = self.vocabs[side]
         bos = vocab[DefaultTokens.BOS]
         eos = vocab[DefaultTokens.EOS]
@@ -150,7 +153,7 @@ class ParallelCorpus(IterableDataset):
 
         def _cast(example_dict):
             return {
-                k: self._numericalize(v, side=k)
+                k: self._maybe_numericalize(k, v)
                 for k, v in example_dict.items()
                 if v is not None
             }

--- a/mammoth/inputters/dataset.py
+++ b/mammoth/inputters/dataset.py
@@ -189,7 +189,6 @@ class ParallelCorpus(IterableDataset):
         examples = map(_cast, examples)
         yield from examples
 
-    # FIXME: some RNN archs require sorting src's by length
     def collate_fn(self, examples, line_idx):
         has_tgt = 'tgt' in examples[0].keys()
         src_padidx = self.vocabs['src'][DefaultTokens.PAD]

--- a/mammoth/inputters/dataset.py
+++ b/mammoth/inputters/dataset.py
@@ -41,7 +41,8 @@ def read_examples_from_files(
 ):
     """Helper function to read examples"""
 
-    line_idx_generator = itertools.count()
+    # match starting line with offset
+    line_idx_generator = itertools.count(offset if offset is not None else 0)
 
     def _make_example_dict(packed):
         """Helper function to convert lines to dicts"""
@@ -160,6 +161,7 @@ class ParallelCorpus(IterableDataset):
 
         # ensure we only restore the first time the corpus is restored
         if self._line_idx_restore is not None:
+            logger.info(f'restoring to line: {self._line_idx_restore}')
             if self.stride is not None:
                 # sanity check
                 assert self._line_idx_restore % self.stride == 0, \

--- a/mammoth/model_builder.py
+++ b/mammoth/model_builder.py
@@ -150,7 +150,7 @@ def load_test_multitask_model(opts, task=None, model_path=None):
 
         model_opts = ArgumentParser.ckpt_model_opts(frame['opts'])
         # Avoid functionality on inference
-        model_opts.update_vocab = False
+        # model_opts.update_vocab = False
         model = create_bilingual_model(
             task=task,
             model_opts=model_opts,
@@ -211,7 +211,7 @@ def load_test_model(opts, model_path=None):
     # fields["indices"] = indices
 
     # Avoid functionality on inference
-    model_opts.update_vocab = False
+    # model_opts.update_vocab = False
 
     if opts.fp32:
         model.float()

--- a/mammoth/models/model_saver.py
+++ b/mammoth/models/model_saver.py
@@ -83,7 +83,7 @@ class ModelSaverBase(object):
                 model_params_data.append(param.data)
                 param.data = avg.data
 
-        chkpt_names = self._save(step, save_model, self.device_context)
+        chkpt_names = self._save(step, save_model, data_state, self.device_context)
         self.last_saved_step = step
 
         if moving_average:
@@ -96,12 +96,14 @@ class ModelSaverBase(object):
                 self._rm_checkpoint(todel)
             self.checkpoint_queue.append(chkpt_names)
 
-    def _save(self, step):
+    def _save(self, step, save_model, data_state, device_context):
         """Save a resumable checkpoint.
 
         Args:
             step (int): step number
             model (nn.Module): torch model to save
+            data_state (dict): data streaming info
+            device_context: runtime info
 
         Returns:
             (object, str):
@@ -126,8 +128,7 @@ class ModelSaverBase(object):
 class ModelSaver(ModelSaverBase):
     """Simple model saver to filesystem"""
 
-    # FIXME does not match the base class signature
-    def _save(self, step, model, device_context, data_state):
+    def _save(self, step, model, data_state, device_context):
         real_model = model.module if isinstance(model, nn.DataParallel) else model
 
         model_state_dict = real_model.state_dict()

--- a/mammoth/models/model_saver.py
+++ b/mammoth/models/model_saver.py
@@ -101,7 +101,7 @@ class ModelSaverBase(object):
 
         Args:
             step (int): step number
-            model (nn.Module): torch model to save
+            save_model (nn.Module): torch model to save
             data_state (dict): data streaming info
             device_context: runtime info
 

--- a/mammoth/tests/test_look_ahead_bucketing.py
+++ b/mammoth/tests/test_look_ahead_bucketing.py
@@ -1,5 +1,5 @@
 import pytest
-from itertools import product
+from itertools import product, count
 
 from mammoth.inputters.dataloader import build_dataloader
 
@@ -22,7 +22,7 @@ class MockStream():
     def __iter__(self):
         return iter(self.items)
 
-    def collate_fn(self, items):
+    def collate_fn(self, items, line_idx):
         return items
 
 

--- a/mammoth/tests/test_look_ahead_bucketing.py
+++ b/mammoth/tests/test_look_ahead_bucketing.py
@@ -1,5 +1,5 @@
 import pytest
-from itertools import product
+from itertools import product, count
 
 from mammoth.inputters.dataloader import build_dataloader
 
@@ -40,10 +40,12 @@ class MockStream():
     ],
 )
 def test_simple_lookeahead_bucketing(max_batch_size, lookahead_minibatches):
+    index_gen = count()
     stream = MockStream([
         hashabledict({
             'src': tuple([letter for _ in range(i)]),
             'tgt': tuple([letter for _ in range(j)]),
+            'line_idx': next(index_gen)
         })
         for letter in 'xyz'
         for i, j in product(range(1, 11), range(1, 11))
@@ -78,10 +80,12 @@ def test_simple_lookeahead_bucketing(max_batch_size, lookahead_minibatches):
     [1, 5, 12, 2048],
 )
 def test_sentence_minibatcher(batch_size):
+    index_gen = count()
     stream = MockStream([
         hashabledict({
             'src': tuple([letter for _ in range(i)]),
             'tgt': tuple([letter for _ in range(j)]),
+            'line_idx': next(index_gen)
         })
         for letter in 'xyz'
         for i, j in product(range(1, 11), range(1, 11))

--- a/mammoth/tests/test_look_ahead_bucketing.py
+++ b/mammoth/tests/test_look_ahead_bucketing.py
@@ -1,5 +1,5 @@
 import pytest
-from itertools import product, count
+from itertools import product
 
 from mammoth.inputters.dataloader import build_dataloader
 

--- a/mammoth/train_single.py
+++ b/mammoth/train_single.py
@@ -35,7 +35,7 @@ def _get_model_opts(opts, checkpoint=None):
             # of previous checkpoints
             opts.tensorboard_log_dir_dated = model_opts.tensorboard_log_dir_dated
         # Override checkpoint's update_embeddings as it defaults to false
-        model_opts.update_vocab = opts.update_vocab
+        # model_opts.update_vocab = opts.update_vocab
     else:
         model_opts = opts
     return model_opts

--- a/mammoth/trainer.py
+++ b/mammoth/trainer.py
@@ -343,13 +343,13 @@ class Trainer(object):
                         break
 
             if self.model_saver is not None and (save_checkpoint_steps != 0 and step % save_checkpoint_steps == 0):
-                self.model_saver.save(step, moving_average=self.moving_average)
+                self.model_saver.save(step, self._data_state, moving_average=self.moving_average)
 
             if train_steps > 0 and step >= train_steps:
                 break
 
         if self.model_saver is not None:
-            self.model_saver.save(step, moving_average=self.moving_average)
+            self.model_saver.save(step, self._data_state, moving_average=self.moving_average)
         if device_context.is_master() and self.report_manager is not None:
             self.report_manager.report_end(step)
         return total_stats

--- a/mammoth/trainer.py
+++ b/mammoth/trainer.py
@@ -186,6 +186,8 @@ class Trainer(object):
 
         self.task_queue_manager = task_queue_manager
 
+        self._data_state = {}
+
         for i in range(len(self.accum_count_l)):
             assert self.accum_count_l[i] > 0
 
@@ -421,6 +423,10 @@ class Trainer(object):
                     f'Received {metadata},\n expected {expected_metadata}'
                 )
             seen_comm_batches.add(comm_batch)
+
+            # update data state
+            self._data_state[metadata.corpus_id] = batch.line_idx
+
             if self.norm_method == "tokens":
                 num_tokens = (
                     batch.labels[1:, :, 0].ne(self.train_loss_md[f'trainloss{metadata.tgt_lang}'].padding_idx).sum()

--- a/mammoth/translate/translator.py
+++ b/mammoth/translate/translator.py
@@ -39,31 +39,18 @@ def build_translator(opts, task, report_score=True, logger=None, out_file=None):
 
     scorer = mammoth.translate.GNMTGlobalScorer.from_opts(opts)
 
-    if model_opts.model_task == ModelTask.LANGUAGE_MODEL:
-        translator = GeneratorLM.from_opts(
-            model,
-            vocabs,
-            opts,
-            model_opts,
-            global_scorer=scorer,
-            out_file=out_file,
-            report_align=opts.report_align,
-            report_score=report_score,
-            logger=logger,
-        )
-    else:
-        translator = Translator.from_opts(
-            model,
-            vocabs,
-            opts,
-            model_opts,
-            global_scorer=scorer,
-            out_file=out_file,
-            report_align=opts.report_align,
-            report_score=report_score,
-            logger=logger,
-            task=task,
-        )
+    translator = Translator.from_opts(
+        model,
+        vocabs,
+        opts,
+        model_opts,
+        global_scorer=scorer,
+        out_file=out_file,
+        report_align=opts.report_align,
+        report_score=report_score,
+        logger=logger,
+        task=task,
+    )
     return translator
 
 
@@ -268,7 +255,7 @@ class Inference(object):
         """
         assert task is not None
         # TODO: maybe add dynamic part
-        cls.validate_task(model_opts.model_task)
+        # cls.validate_task(model_opts.model_task)
 
         return cls(
             model,
@@ -715,10 +702,6 @@ class Inference(object):
 
 
 class Translator(Inference):
-    @classmethod
-    def validate_task(cls, task):
-        if task != ModelTask.SEQ2SEQ:
-            raise ValueError(f"Translator does not support task {task}. Tasks supported: {ModelTask.SEQ2SEQ}")
 
     def _align_forward(self, batch, predictions):
         """
@@ -943,6 +926,7 @@ class Translator(Inference):
         return gold_scores
 
 
+# TODO remove
 class GeneratorLM(Inference):
     @classmethod
     def validate_task(cls, task):


### PR DESCRIPTION
closes #63 .

same idea as v2, didn't bother porting from it.

does not embark bucket states, although this could maybe be done by picking the line indices from all examples in the reservoir. Would come at a (potentially high) communication overhead cost.