### PR TITLE
Deterministic global sampling of corpus ids

### DIFF
--- a/mammoth/bin/train.py
+++ b/mammoth/bin/train.py
@@ -144,7 +144,11 @@ def validate_slurm_node_opts(current_env, world_context, opts):
 
 
 def train(opts):
-    init_logger(opts.log_file, structured_log_file=opts.structured_log_file)
+    init_logger(
+        opts.log_file,
+        log_file_level=opts.log_file_level,
+        structured_log_file=opts.structured_log_file
+    )
     ArgumentParser.validate_train_opts(opts)
     ArgumentParser.update_model_opts(opts)
     ArgumentParser.validate_model_opts(opts)
@@ -226,6 +230,7 @@ def train(opts):
             current_env["RANK"] = str(device_context.global_rank)
             current_env["LOCAL_RANK"] = str(device_context.local_rank)
         else:
+            # Running in a non-distributed context: either single GPU or CPU
             node_rank = 0
             local_rank = 0
             device_context: DeviceContext = world_context.global_to_local(

--- a/mammoth/bin/train.py
+++ b/mammoth/bin/train.py
@@ -240,6 +240,9 @@ def train(opts):
             local_rank=local_rank,
             opts=opts
         )
+        if device_context.is_master():
+            # Enough to log this once
+            logger.info(f'TaskQueueManager: {global_task_queue_manager}')
 
         q = mp.Queue(opts.queue_size)
         semaphore = mp.Semaphore(opts.queue_size)

--- a/mammoth/bin/translate.py
+++ b/mammoth/bin/translate.py
@@ -38,6 +38,7 @@ def translate(opts):
         decoder_id=decoder_id,
         corpus_id=corpus_id,
         weight=1.0,
+        introduce_at_training_step=0,
         corpus_opts=corpus_opts,
         src_vocab=None,
         tgt_vocab=None,

--- a/mammoth/distributed/__init__.py
+++ b/mammoth/distributed/__init__.py
@@ -4,7 +4,7 @@ from mammoth.distributed.communication import (
     batch_producer,
     consumer,
     broadcast_tensors,
-    only_ready_reduce_and_rescale_grads,
+    managed_reduce_and_rescale_grads,
     ErrorHandler,
 )
 from mammoth.distributed.contexts import DeviceContext, WorldContext, DeviceContextEnum
@@ -20,7 +20,7 @@ __all__ = [
     "batch_producer",
     "broadcast_tensors",
     "consumer",
-    "only_ready_reduce_and_rescale_grads",
+    "managed_reduce_and_rescale_grads",
     "ErrorHandler",
     "DeviceContext",
     "WorldContext",

--- a/mammoth/distributed/communication.py
+++ b/mammoth/distributed/communication.py
@@ -56,8 +56,6 @@ def managed_reduce_and_rescale_grads(
     Only if no device trains some parameters (or if the parameters exist on
     exactly one device) is it possible to skip communication entirely.
 
-    The "managed" implementation does not require the forward hook 'has_grad_hook'.
-
     Args:
         named_parameters: tuples of (str, Parameter) defining the parameters to consider
         group: torch.distributed communication group

--- a/mammoth/distributed/communication.py
+++ b/mammoth/distributed/communication.py
@@ -7,6 +7,7 @@ import signal
 import torch
 import torch.distributed
 
+from mammoth.distributed.contexts import DeviceContextEnum
 from mammoth.utils.logging import init_logger, logger
 from mammoth.utils.misc import set_random_seed
 
@@ -263,7 +264,8 @@ def consumer(process_fn, opts, device_context, error_queue, batch_queue, semapho
             f'local_rank {device_context.local_rank}'
         )
         logger.info(f'opts.gpu_ranks {opts.gpu_ranks}')
-        multi_init(opts, device_context.global_rank)
+        if device_context.context == DeviceContextEnum.MULTI_GPU:
+            multi_init(opts, device_context.global_rank)
         # error_queue not passed (is this intentional?)
         process_fn(
             opts,
@@ -280,4 +282,4 @@ def consumer(process_fn, opts, device_context, error_queue, batch_queue, semapho
         # propagate exception to parent process, keeping original traceback
         import traceback
 
-        error_queue.put((opts.gpu_ranks[device_context.node_rank], traceback.format_exc()))
+        error_queue.put((device_context.node_rank, traceback.format_exc()))

--- a/mammoth/distributed/components.py
+++ b/mammoth/distributed/components.py
@@ -1,0 +1,101 @@
+import torch.nn as nn
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import List, Any, Optional
+
+
+class Side(Enum):
+    encoder = auto()
+    decoder = auto()
+
+
+@dataclass
+class DistributedComponent(ABC):
+    """
+    Represents a model component that may be distributed across several
+    devices according to some parameter sharing pattern.
+    """
+    module: nn.Module
+    ranks: List[int]
+    # distributed communication group object, or None if on a single device
+    group: Optional[Any]
+
+    @abstractmethod
+    def get_name(self) -> str:
+        pass
+
+    def named_parameters(self):
+        yield from self.module.named_parameters()
+
+    def min_rank(self) -> int:
+        return min(self.ranks)
+
+
+@dataclass
+class DistributedXCoder(DistributedComponent):
+    side: Side
+    layer_stack_index: int
+    xcoder_id: str
+
+    def get_name(self) -> str:
+        return f'{self.side.name}_{self.layer_stack_index}_{self.xcoder_id}'
+
+    def named_parameters(self):
+        for name, p in self.module.named_parameters():
+            # encoders and decoders contain embeddings and adapters as submodules
+            # however, we want to treat these as distinct DistributedComponents
+            if 'embeddings' not in name and 'adapter' not in name:
+                yield name, p
+
+
+@dataclass
+class DistributedEmbedding(DistributedComponent):
+    side: Side
+    lang: str
+
+    def get_name(self) -> str:
+        side_str = 'src' if self.side == Side.encoder else 'tgt'
+        return f'{side_str}_embeddings_{self.lang}'
+
+
+@dataclass
+class DistributedGenerator(DistributedComponent):
+    lang: str
+
+    def get_name(self) -> str:
+        return f'generator_{self.lang}'
+
+
+@dataclass
+class DistributedAdapter(DistributedComponent):
+    side: Side
+    layer_stack_index: int
+    adapter_group: str
+    sub_id: str
+
+    def get_name(self) -> str:
+        return f'{self.side.name}_adapter_{self.layer_stack_index}_{self.adapter_group}_{self.sub_id}'
+
+
+@dataclass
+class DistributedAttentionBridge(DistributedComponent):
+    def get_name(self) -> str:
+        return 'attention_bridge'
+
+
+@dataclass
+class DistributedComponentAction:
+    """
+    Represents an action to be performed on a particular model component.
+    Actions include init broadcast, gradient communication, optimizer step, checkpoint saving.
+    """
+    component: DistributedComponent
+
+
+@dataclass
+class DistributedComponentActionGradient(DistributedComponentAction):
+    # True: has a real gradient that needs to be communicated
+    # False: send a zero dummy gradient, receive gradient from others
+    has_local_gradient: bool
+    gradient_norm: int

--- a/mammoth/distributed/components.py
+++ b/mammoth/distributed/components.py
@@ -68,6 +68,10 @@ class DistributedComponent(ABC):
     def min_rank(self) -> int:
         return min(self.global_ranks)
 
+    def needs_communication(self) -> bool:
+        # if the component needs communication, a group must be set
+        return self.group is not None
+
 
 @dataclass
 class DistributedXCoder(DistributedComponent, ABC):

--- a/mammoth/distributed/components.py
+++ b/mammoth/distributed/components.py
@@ -19,7 +19,8 @@ class DistributedComponentBuilder:
         else:
             # already seen component must be merged
             old_component = self.components[name]
-            assert type(old_component) == type(component)
+            assert type(old_component) == type(component), \
+                f'Unexpected type {name}: {old_component} != {component}'
             assert old_component.group is None
             assert component.group is None
             old_component.global_ranks.update(component.global_ranks)
@@ -103,7 +104,7 @@ class DistributedEncoder(DistributedXCoder):
 class DistributedDecoder(DistributedXCoder):
     @property
     def side(self) -> Side:
-        return Side.encoder
+        return Side.decoder
 
     @property
     def decoder_id(self) -> str:

--- a/mammoth/distributed/components.py
+++ b/mammoth/distributed/components.py
@@ -2,7 +2,33 @@ import torch.nn as nn
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import List, Any, Optional
+from typing import Set, Any, Optional, Dict
+
+from mammoth.models import NMTModel
+
+
+class DistributedComponentBuilder:
+    def __init__(self):
+        self.components: Dict[str, DistributedComponent] = dict()
+
+    def add(self, component):
+        name = component.get_name()
+        if name not in self.components:
+            # new component
+            self.components[name] = component
+        else:
+            # already seen component must be merged
+            old_component = self.components[name]
+            assert type(old_component) == type(component)
+            assert old_component.group is None
+            assert component.group is None
+            old_component.global_ranks.update(component.global_ranks)
+
+    def __iter__(self):
+        result = []
+        for key in sorted(self.components.keys()):
+            result.append(self.components[key])
+        return iter(result)
 
 
 class Side(Enum):
@@ -16,8 +42,13 @@ class DistributedComponent(ABC):
     Represents a model component that may be distributed across several
     devices according to some parameter sharing pattern.
     """
-    module: nn.Module
-    ranks: List[int]
+    # This was implemented as a separate dataclass instead of making it a mixin
+    # of the nn.Module. The main reason is the need to create and use the
+    # DistributedComponents also in contexts where an initialized model is not
+    # (yet) available: 1) in the dataloader, 2) (after future refactoring) when
+    # creating the Modules that the model consists of.
+
+    global_ranks: Set[int]
     # distributed communication group object, or None if on a single device
     group: Optional[Any]
 
@@ -25,28 +56,61 @@ class DistributedComponent(ABC):
     def get_name(self) -> str:
         pass
 
-    def named_parameters(self):
-        yield from self.module.named_parameters()
+    @abstractmethod
+    def get_module(self, model: NMTModel) -> nn.Module:
+        pass
+
+    def named_parameters(self, model: NMTModel):
+        module = self.get_module(model)
+        yield from module.named_parameters()
 
     def min_rank(self) -> int:
-        return min(self.ranks)
+        return min(self.global_ranks)
 
 
 @dataclass
-class DistributedXCoder(DistributedComponent):
-    side: Side
+class DistributedXCoder(DistributedComponent, ABC):
     layer_stack_index: int
     xcoder_id: str
 
     def get_name(self) -> str:
         return f'{self.side.name}_{self.layer_stack_index}_{self.xcoder_id}'
 
-    def named_parameters(self):
-        for name, p in self.module.named_parameters():
+    def named_parameters(self, model: NMTModel):
+        module = self.get_module(model)
+        for name, p in module.named_parameters():
             # encoders and decoders contain embeddings and adapters as submodules
             # however, we want to treat these as distinct DistributedComponents
             if 'embeddings' not in name and 'adapter' not in name:
                 yield name, p
+
+
+@dataclass
+class DistributedEncoder(DistributedXCoder):
+    @property
+    def side(self) -> Side:
+        return Side.encoder
+
+    @property
+    def encoder_id(self) -> str:
+        return self.xcoder_id
+
+    def get_module(self, model: NMTModel) -> nn.Module:
+        return model.encoder.get_submodule(self.layer_stack_index, self.xcoder_id)
+
+
+@dataclass
+class DistributedDecoder(DistributedXCoder):
+    @property
+    def side(self) -> Side:
+        return Side.encoder
+
+    @property
+    def decoder_id(self) -> str:
+        return self.xcoder_id
+
+    def get_module(self, model: NMTModel) -> nn.Module:
+        return model.decoder.get_submodule(self.layer_stack_index, self.xcoder_id)
 
 
 @dataclass
@@ -58,6 +122,12 @@ class DistributedEmbedding(DistributedComponent):
         side_str = 'src' if self.side == Side.encoder else 'tgt'
         return f'{side_str}_embeddings_{self.lang}'
 
+    def get_module(self, model: NMTModel) -> nn.Module:
+        if self.side == Side.encoder:
+            return model.encoder.embeddings[f'embeddings_{self.lang}']
+        else:
+            return model.decoder.embeddings[f'embeddings_{self.lang}']
+
 
 @dataclass
 class DistributedGenerator(DistributedComponent):
@@ -66,9 +136,14 @@ class DistributedGenerator(DistributedComponent):
     def get_name(self) -> str:
         return f'generator_{self.lang}'
 
+    def get_module(self, model: NMTModel) -> nn.Module:
+        return model.generator[f'generator_{self.lang}']
+
 
 @dataclass
 class DistributedAdapter(DistributedComponent):
+    # Can't use parent object of type DistributedXCoder: that refers to a
+    # specific module, while the adapter is for the entire layerstack slot
     side: Side
     layer_stack_index: int
     adapter_group: str
@@ -77,11 +152,20 @@ class DistributedAdapter(DistributedComponent):
     def get_name(self) -> str:
         return f'{self.side.name}_adapter_{self.layer_stack_index}_{self.adapter_group}_{self.sub_id}'
 
+    def get_module(self, model: NMTModel) -> nn.Module:
+        if self.side == Side.encoder:
+            model.encoder.get_adapter(self.adapter_group, self.sub_id)
+        else:
+            model.decoder.get_adapter(self.adapter_group, self.sub_id)
+
 
 @dataclass
 class DistributedAttentionBridge(DistributedComponent):
     def get_name(self) -> str:
         return 'attention_bridge'
+
+    def get_module(self, model: NMTModel) -> Optional[nn.Module]:
+        return self.model.attention_bridge
 
 
 @dataclass
@@ -94,7 +178,7 @@ class DistributedComponentAction:
 
 
 @dataclass
-class DistributedComponentActionGradient(DistributedComponentAction):
+class DistributedComponentActionWithGradient(DistributedComponentAction):
     # True: has a real gradient that needs to be communicated
     # False: send a zero dummy gradient, receive gradient from others
     has_local_gradient: bool

--- a/mammoth/distributed/components.py
+++ b/mammoth/distributed/components.py
@@ -68,6 +68,7 @@ class DistributedComponent(ABC):
         module = self.get_module(model)
         yield from module.named_parameters()
 
+    @property
     def min_rank(self) -> int:
         return min(self.global_ranks)
 

--- a/mammoth/distributed/contexts.py
+++ b/mammoth/distributed/contexts.py
@@ -29,7 +29,7 @@ class WorldContext:
         """Data tensors must be moved to the GPU for compute"""
         return self.context != DeviceContextEnum.CPU
 
-    def global_to_local(self, node_rank, local_rank):
+    def global_to_local(self, node_rank: int, local_rank: int) -> "DeviceContext":
         assert node_rank is not None
         assert local_rank is not None
         return DeviceContext(
@@ -41,7 +41,7 @@ class WorldContext:
         )
 
     @classmethod
-    def from_opts(cls, opts):
+    def from_opts(cls, opts) -> "WorldContext":
         gpus_per_node = len(opts.gpu_ranks)
         world_size = int(opts.world_size) if gpus_per_node > 0 else 0
         multinode = gpus_per_node != world_size

--- a/mammoth/inputters/dataloader.py
+++ b/mammoth/inputters/dataloader.py
@@ -286,7 +286,7 @@ class DynamicDatasetIter(object):
 
     def _init_datasets(self):
         self.dataset_iterators = dict()
-        for task in self.task_queue_manager.get_tasks():
+        for task in self.task_queue_manager.get_my_tasks():
             src_vocab = self.vocabs_dict[('src', task.src_lang)]
             tgt_vocab = self.vocabs_dict[('tgt', task.tgt_lang)]
             # merged_fields = {'src': src_fields['src'], 'tgt': tgt_fields['tgt']}

--- a/mammoth/inputters/dataloader.py
+++ b/mammoth/inputters/dataloader.py
@@ -341,7 +341,7 @@ class DynamicDatasetIter(object):
                 batch_task_sample = self.task_queue_manager.sample_corpus_ids()
                 my_task = batch_task_sample.tasks[self.task_queue_manager.global_rank]
                 ordered_iter, metadata = self.dataset_iterators[my_task.corpus_id]
-                for _ in self.task_queue_manager.accum_count:
+                for _ in range(self.task_queue_manager.accum_count):
                     batch = next(ordered_iter)
                     if batch_task_sample.training_step == 0:
                         # De-numericalize a few sentences for debugging

--- a/mammoth/inputters/dataloader.py
+++ b/mammoth/inputters/dataloader.py
@@ -1,7 +1,6 @@
 import collections
 import itertools
 import math
-import logging
 
 import torch
 

--- a/mammoth/inputters/dataloader.py
+++ b/mammoth/inputters/dataloader.py
@@ -93,14 +93,14 @@ class LookAheadBucketing():
         self._init()
 
     def _init(self):
-        logger.info('LookAheadBucketing: initialization start')
+        # logger.info('LookAheadBucketing: initialization start')
         self.examples_stream = iter(self.dataset)
         for example in range(self.look_ahead_size):
             self.maybe_replenish()
             if self._is_exhausted:
                 break
         assert not self.is_empty(), 'Dataset contains no usable example!'
-        logger.info('LookAheadBucketing: initialization done')
+        # logger.info('LookAheadBucketing: initialization done')
 
     def maybe_replenish(self):
         """try to look up one more example to add to this reservoir."""
@@ -351,7 +351,7 @@ class DynamicDatasetIter(object):
                         )
                         src_vocab = self.vocabs_dict[('src', metadata.src_lang)]
                         tgt_vocab = self.vocabs_dict[('tgt', metadata.tgt_lang)]
-                        for sent_idx in range(3):
+                        for sent_idx in range(min(3, batch.src[0].shape[2])):
                             toks = [src_vocab.itos[tok_id.item()] for tok_id in batch.src[0][:, sent_idx, 0]]
                             logger.warning(f'{sent_idx} {metadata.src_lang} src: {" ".join(toks)}')
                             toks = [tgt_vocab.itos[tok_id.item()] for tok_id in batch.tgt[:, sent_idx, 0]]

--- a/mammoth/inputters/dataloader.py
+++ b/mammoth/inputters/dataloader.py
@@ -1,6 +1,7 @@
 import collections
 import itertools
 import math
+import logging
 
 import torch
 
@@ -280,7 +281,7 @@ class DynamicDatasetIter(object):
                 ordered_iter, metadata = self.dataset_iterators[my_task.corpus_id]
                 for _ in range(self.task_queue_manager.accum_count):
                     batch = next(ordered_iter)
-                    if batch_task_sample.training_step == 0:
+                    if batch_task_sample.training_step == 0 and self.opts.verbose:
                         # De-numericalize a few sentences for debugging
                         logger.warning(
                             f'src shape: {batch.src[0].shape} tgt shape: {batch.tgt.shape} '

--- a/mammoth/model_builder.py
+++ b/mammoth/model_builder.py
@@ -297,13 +297,13 @@ def build_task_specific_model(
     generators_md = nn.ModuleDict()
 
     # FIXME: it's getting late and I just want this to compile
-    for side, lang, _, vocab in task_queue_manager.get_vocabs(side='src', vocabs_dict=vocabs_dict):
+    for side, lang, _, vocab in task_queue_manager.get_my_vocabs(side='src', vocabs_dict=vocabs_dict):
         src_emb = build_src_emb(model_opts, vocab)
         src_embs[lang] = src_emb
     pluggable_src_emb = PluggableEmbeddings(src_embs)
     encoder = build_only_enc(model_opts, pluggable_src_emb, task_queue_manager, checkpoint)
 
-    for side, lang, _, vocab in task_queue_manager.get_vocabs(side='tgt', vocabs_dict=vocabs_dict):
+    for side, lang, _, vocab in task_queue_manager.get_my_vocabs(side='tgt', vocabs_dict=vocabs_dict):
         tgt_emb = build_tgt_emb(model_opts, vocab)
         tgt_embs[lang] = tgt_emb
         generator = build_generator(model_opts, len(vocab), tgt_emb)
@@ -579,7 +579,7 @@ def create_all_adapters(model, opts, task_queue_manager):
     my_dec_adapter_ids = set()
     adapter_to_encoder_ids = defaultdict(set)
     adapter_to_decoder_ids = defaultdict(set)
-    for task in task_queue_manager.get_tasks():
+    for task in task_queue_manager.get_my_tasks():
         for adapter_id in task.encoder_adapter_ids:
             adapter_id = tuple(adapter_id)
             my_enc_adapter_ids.add(adapter_id)

--- a/mammoth/model_builder.py
+++ b/mammoth/model_builder.py
@@ -356,28 +356,6 @@ def build_task_specific_model(
     print('built model:')
     print(nmt_model)
 
-    # register a forward hook to keep track of which parameters have valid gradients.
-    # p.grad is None can not be used: grad is None only before first update.
-    # zero_grad typically sets the grad to zero, not to None.
-    # While zero_grad takes a flag set_to_none, it is not reliably forwarded by various optimizers.
-    def has_grad_hook(module, input, output) -> None:
-        for param in module.parameters(recurse=False):
-            if param.requires_grad:
-                # NB: we're looking at whether gradient will/has been computed, which is only the
-                # case when the module is training.
-                param.has_grad = module.training
-
-    for module in nmt_model.modules():
-        module.register_forward_hook(has_grad_hook)
-        for param in module.parameters(recurse=False):
-            if param.requires_grad:
-                param.has_grad = False
-    for module in generators_md.modules():
-        module.register_forward_hook(has_grad_hook)
-        for param in module.parameters(recurse=False):
-            if param.requires_grad:
-                param.has_grad = False
-
     return nmt_model, generators_md
 
 

--- a/mammoth/model_builder.py
+++ b/mammoth/model_builder.py
@@ -287,7 +287,7 @@ def build_task_specific_model(
     task_queue_manager,
     checkpoint,
 ):
-    logger.info(f'TaskQueueManager: {task_queue_manager}')
+    # logger.info(f'TaskQueueManager: {task_queue_manager}')
     if not model_opts.model_task == ModelTask.SEQ2SEQ:
         raise ValueError(f"Only ModelTask.SEQ2SEQ works - {model_opts.model_task} task")
 

--- a/mammoth/modules/layer_stack_decoder.py
+++ b/mammoth/modules/layer_stack_decoder.py
@@ -23,7 +23,7 @@ class LayerStackDecoder(DecoderBase):
         for layer_stack_index, n_layers in enumerate(opts.dec_layers):
             is_on_top = layer_stack_index == len(opts.dec_layers) - 1
             stacks = nn.ModuleDict()
-            for module_id in task_queue_manager.get_decoders(layer_stack_index):
+            for module_id in task_queue_manager.get_my_decoders(layer_stack_index):
                 if module_id in stacks:
                     # several tasks using the same layer stack
                     continue

--- a/mammoth/modules/layer_stack_encoder.py
+++ b/mammoth/modules/layer_stack_encoder.py
@@ -1,5 +1,5 @@
 from torch import nn
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from mammoth.modules.encoder import EncoderBase
 from mammoth.models.adapters import Adapter, AdaptedTransformerEncoder

--- a/mammoth/modules/layer_stack_encoder.py
+++ b/mammoth/modules/layer_stack_encoder.py
@@ -23,7 +23,7 @@ class LayerStackEncoder(EncoderBase):
         for layer_stack_index, n_layers in enumerate(opts.enc_layers):
             stacks = nn.ModuleDict()
             is_on_top = layer_stack_index == len(opts.enc_layers) - 1
-            for module_id in task_queue_manager.get_encoders(layer_stack_index):
+            for module_id in task_queue_manager.get_my_encoders(layer_stack_index):
                 if module_id in stacks:
                     # several tasks using the same layer stack
                     continue

--- a/mammoth/modules/layer_stack_encoder.py
+++ b/mammoth/modules/layer_stack_encoder.py
@@ -1,5 +1,5 @@
 from torch import nn
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from mammoth.modules.encoder import EncoderBase
 from mammoth.models.adapters import Adapter, AdaptedTransformerEncoder
@@ -120,9 +120,12 @@ class LayerStackEncoder(EncoderBase):
     def get_submodule(self, layer_stack_index: int, module_id: str):
         return self.encoders[layer_stack_index][module_id]
 
-    def get_adapter(self, module_id: str, adapter_group: str, sub_id: str):
+    def get_adapter(self, adapter_group: str, sub_id: str):
         name = Adapter._name(adapter_group, sub_id)
         layer_stack_index = self._adapter_to_stack[name]
+        # All module_ids in the same slot (should) have the same adapters.
+        # Thus, we can select one arbitrarily.
+        module_id = sorted(self.encoders[layer_stack_index].keys())[0]
         return self.encoders[layer_stack_index][module_id].get_adapter(adapter_group, sub_id)
 
     def add_adapter(

--- a/mammoth/opts.py
+++ b/mammoth/opts.py
@@ -93,8 +93,9 @@ def _add_reproducibility_opts(parser):
         '--seed',
         '-seed',
         type=int,
-        default=-1,
-        help="Set random seed used for better reproducibility between experiments.",
+        required=True,
+        help="Set random seed used for better reproducibility between experiments. "
+        "Mandatory for multi-gpu training, and for convenience required for all.",
     )
 
 

--- a/mammoth/opts.py
+++ b/mammoth/opts.py
@@ -1014,14 +1014,15 @@ def _add_train_dynamic_data(parser):
         "--pool_size",
         type=int,
         default=2048,
-        help="Number of examples to dynamically pool before batching.",
+        help="(Maximum) number of examples to dynamically pool before batching.",
     )
     group.add(
         "-n_buckets",
         "--n_buckets",
         type=int,
-        default=1024,
-        help="Maximum number of bins for batching.",
+        default=4,
+        help="The number of minibatches that will be yielded once bucketing is complete. "
+        "Recommended value: same as accum_count, or at least a multiple of it."
     )
 
 
@@ -1236,13 +1237,13 @@ def translate_opts(parser, dynamic=False):
     _add_logging_opts(parser, is_train=False)
 
     group = parser.add_argument_group('Efficiency')
-    group.add('--batch_size', '-batch_size', type=int, default=30, help='Batch size')
+    group.add('--batch_size', '-batch_size', type=int, default=300, help='Batch size')
     group.add(
         '--batch_type',
         '-batch_type',
-        default='sents',
+        default='tokens',
         choices=["sents", "tokens"],
-        help="Batch grouping for batch_size. Standard is sents. Tokens will do dynamic batching",
+        help="Batch grouping for batch_size. Standard is tokens (max of src and tgt). Sents is unimplemented.",
     )
     group.add('--gpu', '-gpu', type=int, default=-1, help="Device to run on")
 

--- a/mammoth/tests/test_models.py
+++ b/mammoth/tests/test_models.py
@@ -14,7 +14,10 @@ mammoth.opts.model_opts(parser)
 mammoth.opts._add_train_general_opts(parser)
 
 # -data option is required, but not used in this test, so dummy.
-opts = parser.parse_known_args(['-tasks', 'dummy', '-node_rank', '0', '-model_dim', '500'], strict=False)[0]
+opts = parser.parse_known_args(
+    ['-tasks', 'dummy', '-node_rank', '0', '-model_dim', '500', '-seed', '1'],
+    strict=False
+)[0]
 
 
 class TestModel(unittest.TestCase):

--- a/mammoth/tests/test_task_distribution_strategy.py
+++ b/mammoth/tests/test_task_distribution_strategy.py
@@ -1,110 +1,88 @@
-import pytest
-from argparse import Namespace
+from collections import defaultdict, Counter
 
-from mammoth.distributed.tasks import WeightedSamplingTaskDistributionStrategy, RoundRobinTaskDistributionStrategy
-
-
-def test_weights_all_zero():
-    opts = Namespace(tasks={
-        'a': {
-            'weight': 0,
-            'introduce_at_training_step': 0,
-        },
-        'b': {
-            'weight': 0,
-            'introduce_at_training_step': 0,
-        },
-        'notmine': {
-            'weight': 10,
-            'introduce_at_training_step': 0,
-        },
-    })
-    with pytest.raises(ValueError) as exc_info:
-        WeightedSamplingTaskDistributionStrategy.from_opts(['a', 'b'], opts)
-    assert 'Can not set "weight" of all corpora on a device to zero' in str(exc_info.value)
+from mammoth.distributed.tasks import (
+    WeightedSamplingTaskDistributionStrategy,
+    RoundRobinTaskDistributionStrategy,
+    TaskSpecs,
+)
 
 
-def test_weights_all_postponed():
-    opts = Namespace(tasks={
-        'a': {
-            'weight': 1,
-            'introduce_at_training_step': 1,
-        },
-        'b': {
-            'weight': 1,
-            'introduce_at_training_step': 10,
-        },
-        'notmine': {
-            'weight': 10,
-            'introduce_at_training_step': 0,
-        },
-    })
-    with pytest.raises(ValueError) as exc_info:
-        WeightedSamplingTaskDistributionStrategy.from_opts(['a', 'b'], opts)
-    assert 'Can not set "introduce_at_training_step" of all corpora on a device to nonzero' in str(exc_info.value)
-
-
-def test_invalid_curriculum():
-    opts = Namespace(tasks={
-        # 'a' disabled by weight
-        'a': {
-            'weight': 0,
-            'introduce_at_training_step': 0,
-        },
-        # 'b' postponed
-        'b': {
-            'weight': 1,
-            'introduce_at_training_step': 10,
-        },
-        'notmine': {
-            'weight': 10,
-            'introduce_at_training_step': 0,
-        },
-    })
-    with pytest.raises(ValueError) as exc_info:
-        WeightedSamplingTaskDistributionStrategy.from_opts(['a', 'b'], opts)
-    assert 'Invalid curriculum' in str(exc_info.value)
+def make_dummy_task(corpus_id, weight):
+    return TaskSpecs(
+        node_rank=0,
+        local_rank=0,
+        src_lang='src',
+        tgt_lang='tgt',
+        encoder_id=['enc'],
+        decoder_id=['dec'],
+        corpus_id=corpus_id,
+        weight=weight,
+        introduce_at_training_step=0,
+        corpus_opts=dict(),
+        src_vocab=None,
+        tgt_vocab=None,
+        encoder_adapter_ids=None,
+        decoder_adapter_ids=None,
+    )
 
 
 def test_sampling_task_distribution_strategy():
-    opts = Namespace(tasks={
-        # 'a' disabled by weight
-        'a': {
-            'weight': 0,
-            'introduce_at_training_step': 0,
-        },
-        # 'b' postponed longer than n_batches
-        'b': {
-            'weight': 1,
-            'introduce_at_training_step': 9999,
-        },
-        # 'c' is the only valid corpus
-        'c': {
-            'weight': 1,
-            'introduce_at_training_step': 0,
-        },
-        # 'notmine' is not on this device
-        'notmine': {
-            'weight': 10,
-            'introduce_at_training_step': 0,
-        },
-    })
-    strategy = WeightedSamplingTaskDistributionStrategy.from_opts(['a', 'b', 'c'], opts)
-    all_samples = []
-    n_samples = 10
+    n_devices = 2
+    active_tasks = {
+        0: [
+            make_dummy_task('a', 50),
+            make_dummy_task('b', 50),
+        ],
+        1: [
+            make_dummy_task('c', 1),
+        ],
+    }
+    strategy = WeightedSamplingTaskDistributionStrategy(seed=1)
+    all_samples = defaultdict(Counter)
     n_batches = 1000
     for i in range(n_batches):
-        sampled_corpus_ids = strategy.sample_corpus_ids(n_samples=n_samples, communication_batch_id=i)
-        assert len(sampled_corpus_ids) == n_samples
-        all_samples.extend(sampled_corpus_ids)
-    assert len(all_samples) == n_samples * n_batches
-    # 'c' is the only valid corpus, nothing else should be drawn
-    assert set(all_samples) == {'c'}
+        batch_task_sample = strategy.sample_corpus_ids(active_tasks)
+        assert batch_task_sample.training_step == i
+        assert len(batch_task_sample.tasks) == n_devices
+        for global_rank, task in batch_task_sample.tasks.items():
+            all_samples[global_rank][task.corpus_id] += 1
+    total_count = sum(sum(counts.values()) for counts in all_samples.values())
+    assert total_count == n_devices * n_batches
+    # 0 should sample from both tasks
+    assert all_samples[0]['a'] > 0
+    assert all_samples[0]['b'] > 0
+    # 'c' is the only valid corpus for 1, nothing else should be drawn
+    assert all_samples[1] == Counter({'c': n_batches})
 
 
 def test_round_robin_task_distribution_strategy():
-    strategy = RoundRobinTaskDistributionStrategy(['a', 'b'])
-    first_five = strategy.sample_corpus_ids(n_samples=5, communication_batch_id=0)
-    assert first_five == ['a', 'b', 'a', 'b', 'a']
-    next_two = strategy.sample_corpus_ids(n_samples=2, communication_batch_id=0)
-    assert next_two == ['b', 'a']
+    n_devices = 2
+    active_tasks = {
+        0: [
+            make_dummy_task('a', 50),
+            make_dummy_task('b', 50),
+        ],
+        1: [
+            make_dummy_task('c', 1),
+        ],
+    }
+    strategy = RoundRobinTaskDistributionStrategy(seed=1)
+    all_samples = defaultdict(Counter)
+    n_batches = 1000
+    for i in range(n_batches):
+        batch_task_sample = strategy.sample_corpus_ids(active_tasks)
+        assert batch_task_sample.training_step == i
+        assert len(batch_task_sample.tasks) == n_devices
+        for global_rank, task in batch_task_sample.tasks.items():
+            all_samples[global_rank][task.corpus_id] += 1
+    total_count = sum(sum(counts.values()) for counts in all_samples.values())
+    assert total_count == n_devices * n_batches
+    # 0 should sample from both tasks
+    assert all_samples[0] == Counter(
+        {
+            'a': n_batches // 2,
+            'b': n_batches // 2,
+        }
+    )
+    # 'c' is the only valid corpus for 1, nothing else should be drawn
+    assert all_samples[1] == Counter({'c': n_batches})

--- a/mammoth/tests/test_task_queue_manager.py
+++ b/mammoth/tests/test_task_queue_manager.py
@@ -144,15 +144,15 @@ def test_create_all_distributed_components():
         use_attention_bridge=False, new_group_func=MockGroup()
     )
     assert all_components == [
+        DistributedDecoder(
+            global_ranks={0, 2}, group='Group 0 with GPU ranks [0, 2]', layer_stack_index=0, xcoder_id='y'
+        ),
+        DistributedDecoder(global_ranks={1}, group=None, layer_stack_index=0, xcoder_id='yy'),
         DistributedEncoder(
-            global_ranks={0, 1}, group='Group 0 with GPU ranks [0, 1]', layer_stack_index=0, xcoder_id='x'
+            global_ranks={0, 1}, group='Group 1 with GPU ranks [0, 1]', layer_stack_index=0, xcoder_id='x'
         ),
         DistributedEncoder(global_ranks={1}, group=None, layer_stack_index=0, xcoder_id='xx'),
         DistributedEncoder(global_ranks={2}, group=None, layer_stack_index=0, xcoder_id='xxx'),
-        DistributedDecoder(
-            global_ranks={0, 2}, group='Group 1 with GPU ranks [0, 2]', layer_stack_index=0, xcoder_id='y'
-        ),
-        DistributedDecoder(global_ranks={1}, group=None, layer_stack_index=0, xcoder_id='yy'),
         DistributedGenerator(global_ranks={0, 2}, group='Group 2 with GPU ranks [0, 2]', lang='b'),
         DistributedGenerator(global_ranks={1}, group=None, lang='d'),
         DistributedEmbedding(global_ranks={0, 1}, group='Group 3 with GPU ranks [0, 1]', side=Side.encoder, lang='a'),
@@ -183,11 +183,11 @@ def test_get_my_distributed_components():
         if component not in all_components:
             raise Exception(f'my component {component} not in all_components {all_components}')
     assert my_components == [
+        DistributedDecoder(global_ranks={1}, group=None, layer_stack_index=0, xcoder_id='yy'),
         DistributedEncoder(
-            global_ranks={0, 1}, group='Group 0 with GPU ranks [0, 1]', layer_stack_index=0, xcoder_id='x'
+            global_ranks={0, 1}, group='Group 1 with GPU ranks [0, 1]', layer_stack_index=0, xcoder_id='x'
         ),
         DistributedEncoder(global_ranks={1}, group=None, layer_stack_index=0, xcoder_id='xx'),
-        DistributedDecoder(global_ranks={1}, group=None, layer_stack_index=0, xcoder_id='yy'),
         DistributedGenerator(global_ranks={1}, group=None, lang='d'),
         DistributedEmbedding(global_ranks={0, 1}, group='Group 3 with GPU ranks [0, 1]', side=Side.encoder, lang='a'),
         DistributedEmbedding(global_ranks={1}, group=None, side=Side.encoder, lang='c'),

--- a/mammoth/tests/test_task_queue_manager.py
+++ b/mammoth/tests/test_task_queue_manager.py
@@ -35,8 +35,6 @@ def test_init_minimal():
         task_queue_manager.local_rank
     assert [task.node_rank for task in task_queue_manager.tasks] == [0, 0]
     assert [task.local_rank for task in task_queue_manager.tasks] == [0, 1]
-    assert task_queue_manager.get_encoders(0) == ['a', 'c']
-    assert task_queue_manager.get_decoders(0) == ['b', 'd']
 
 
 def create_basic_task_queue_manager():
@@ -147,7 +145,7 @@ def test_create_all_distributed_groups():
     }
 
 
-def test_get_distributed_groups():
+def test_get_my_distributed_groups():
     class MockGroup:
         def __init__(self):
             self.group_idx = 0
@@ -159,7 +157,7 @@ def test_get_distributed_groups():
 
     global_task_queue_manager, opts = create_basic_task_queue_manager()
     task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=1, opts=opts)
-    my_groups = task_queue_manager.get_distributed_groups(new_group_func=MockGroup())
+    my_groups = task_queue_manager.get_my_distributed_groups(new_group_func=MockGroup())
     assert my_groups == {
         'encoder': OrderedDict({
             (0, 'x'): (0, 'Group 2 with GPU ranks [0, 1]'),
@@ -201,7 +199,7 @@ def test_cpu_distributed_groups():
     global_task_queue_manager = TaskQueueManager.from_opts(opts, world_context)
     task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=0, opts=opts)
     new_group_func = MagicMock().new_group_func
-    my_groups = task_queue_manager.get_distributed_groups(new_group_func=new_group_func)
+    my_groups = task_queue_manager.get_my_distributed_groups(new_group_func=new_group_func)
     # No groups should be created when running on CPU
     new_group_func.assert_not_called()
     # The component keys should still exist, but be empty
@@ -253,7 +251,7 @@ def test_distributed_groups_no_encoder_group():
     global_task_queue_manager = TaskQueueManager.from_opts(opts, world_context)
     task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=0, opts=opts)
     new_group_func = MagicMock().new_group_func
-    my_groups = task_queue_manager.get_distributed_groups(new_group_func=new_group_func)
+    my_groups = task_queue_manager.get_my_distributed_groups(new_group_func=new_group_func)
     # No groups should be created:
     # AB is fully shared (doesn't need a group),
     # and all other components are not shared at all
@@ -292,25 +290,25 @@ def test_distributed_groups_no_encoder_group():
 def test_basic_getters():
     global_task_queue_manager, opts = create_basic_task_queue_manager()
     task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=0, opts=opts)
-    encoders = list(task_queue_manager.get_encoders(0))
+    encoders = list(task_queue_manager.get_my_encoders(0))
     assert encoders == ['x']
-    decoders = list(task_queue_manager.get_decoders(0))
+    decoders = list(task_queue_manager.get_my_decoders(0))
     assert decoders == ['y']
-    src_langs = list(task_queue_manager.get_src_langs())
+    src_langs = list(task_queue_manager.get_my_src_langs())
     assert src_langs == ['a']
-    tgt_langs = list(task_queue_manager.get_tgt_langs())
+    tgt_langs = list(task_queue_manager.get_my_tgt_langs())
     assert tgt_langs == ['b']
-    generators = list(task_queue_manager.get_generators())
+    generators = list(task_queue_manager.get_my_generators())
     assert generators == ['b']
 
     task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=1, opts=opts)
-    encoders = list(task_queue_manager.get_encoders(0))
+    encoders = list(task_queue_manager.get_my_encoders(0))
     assert encoders == ['xx', 'x']
-    decoders = list(task_queue_manager.get_decoders(0))
+    decoders = list(task_queue_manager.get_my_decoders(0))
     assert decoders == ['yy', 'yy']
-    src_langs = list(task_queue_manager.get_src_langs())
+    src_langs = list(task_queue_manager.get_my_src_langs())
     assert src_langs == ['c', 'a']
-    tgt_langs = list(task_queue_manager.get_tgt_langs())
+    tgt_langs = list(task_queue_manager.get_my_tgt_langs())
     assert tgt_langs == ['d', 'd']
-    generators = list(task_queue_manager.get_generators())
+    generators = list(task_queue_manager.get_my_generators())
     assert generators == ['d', 'd']

--- a/mammoth/tests/test_task_queue_manager.py
+++ b/mammoth/tests/test_task_queue_manager.py
@@ -1,13 +1,24 @@
 import pytest
 from argparse import Namespace
-from collections import OrderedDict
 from unittest.mock import MagicMock
 
 from mammoth.distributed import TaskQueueManager, WorldContext
+from mammoth.distributed.components import (
+    Side,
+    DistributedEncoder,
+    DistributedDecoder,
+    DistributedEmbedding,
+    DistributedGenerator,
+    # DistributedAdapter,
+    # DistributedAttentionBridge,
+    # DistributedComponentAction,
+    # DistributedComponentActionWithGradient,
+)
 
 
 def test_init_minimal():
     opt_dict = {
+        'seed': 1024,
         'accum_count': 1,
         'task_distribution_strategy': 'roundrobin',
         'world_size': 2,
@@ -18,7 +29,7 @@ def test_init_minimal():
         'tasks': {
             'train_a-b': {'path_src': 'dummy', 'path_tgt': 'dummy', 'src_tgt': 'a-b'},
             'train_c-d': {'path_src': 'dummy', 'path_tgt': 'dummy', 'src_tgt': 'c-d'},
-        }
+        },
     }
     opts = Namespace(**opt_dict)
     world_context = WorldContext.from_opts(opts)
@@ -39,6 +50,7 @@ def test_init_minimal():
 
 def create_basic_task_queue_manager():
     opt_dict = {
+        'seed': 1024,
         'accum_count': 8,
         'task_distribution_strategy': 'weighted_sampling',
         'world_size': 4,
@@ -91,7 +103,7 @@ def create_basic_task_queue_manager():
                 'enc_sharing_group': ['xx'],
                 'dec_sharing_group': ['yy'],
             },
-        }
+        },
     }
     opts = Namespace(**opt_dict)
     world_context = WorldContext.from_opts(opts)
@@ -117,7 +129,7 @@ def test_init_basic():
     assert [task.tgt_lang for task in task_queue_manager.tasks] == ['b', 'd', 'd', 'b']
 
 
-def test_create_all_distributed_groups():
+def test_create_all_distributed_components():
     class MockGroup:
         def __init__(self):
             self.group_idx = 0
@@ -128,24 +140,30 @@ def test_create_all_distributed_groups():
             return result
 
     global_task_queue_manager, opts = create_basic_task_queue_manager()
-    all_groups = global_task_queue_manager.create_all_distributed_groups(new_group_func=MockGroup())
-    assert all_groups == {
-        'src_emb': OrderedDict({
-            ('a',): (0, 'Group 0 with GPU ranks [0, 1]'),
-        }),
-        'tgt_emb': OrderedDict({
-            ('b',): (0, 'Group 1 with GPU ranks [0, 2]'),
-        }),
-        'encoder': OrderedDict({
-            (0, 'x'): (0, 'Group 2 with GPU ranks [0, 1]'),
-        }),
-        'decoder': OrderedDict({
-            (0, 'y'): (0, 'Group 3 with GPU ranks [0, 2]'),
-        }),
-    }
+    all_components = global_task_queue_manager.create_all_distributed_components(
+        use_attention_bridge=False, new_group_func=MockGroup()
+    )
+    assert all_components == [
+        DistributedEncoder(
+            global_ranks={0, 1}, group='Group 0 with GPU ranks [0, 1]', layer_stack_index=0, xcoder_id='x'
+        ),
+        DistributedEncoder(global_ranks={1}, group=None, layer_stack_index=0, xcoder_id='xx'),
+        DistributedEncoder(global_ranks={2}, group=None, layer_stack_index=0, xcoder_id='xxx'),
+        DistributedDecoder(
+            global_ranks={0, 2}, group='Group 1 with GPU ranks [0, 2]', layer_stack_index=0, xcoder_id='y'
+        ),
+        DistributedDecoder(global_ranks={1}, group=None, layer_stack_index=0, xcoder_id='yy'),
+        DistributedGenerator(global_ranks={0, 2}, group='Group 2 with GPU ranks [0, 2]', lang='b'),
+        DistributedGenerator(global_ranks={1}, group=None, lang='d'),
+        DistributedEmbedding(global_ranks={0, 1}, group='Group 3 with GPU ranks [0, 1]', side=Side.encoder, lang='a'),
+        DistributedEmbedding(global_ranks={1}, group=None, side=Side.encoder, lang='c'),
+        DistributedEmbedding(global_ranks={2}, group=None, side=Side.encoder, lang='e'),
+        DistributedEmbedding(global_ranks={0, 2}, group='Group 4 with GPU ranks [0, 2]', side=Side.decoder, lang='b'),
+        DistributedEmbedding(global_ranks={1}, group=None, side=Side.decoder, lang='d'),
+    ]
 
 
-def test_get_my_distributed_groups():
+def test_get_my_distributed_components():
     class MockGroup:
         def __init__(self):
             self.group_idx = 0
@@ -156,24 +174,30 @@ def test_get_my_distributed_groups():
             return result
 
     global_task_queue_manager, opts = create_basic_task_queue_manager()
+    all_components = global_task_queue_manager.create_all_distributed_components(
+        use_attention_bridge=False, new_group_func=MockGroup()
+    )
     task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=1, opts=opts)
-    my_groups = task_queue_manager.get_my_distributed_groups(new_group_func=MockGroup())
-    assert my_groups == {
-        'encoder': OrderedDict({
-            (0, 'x'): (0, 'Group 2 with GPU ranks [0, 1]'),
-        }),
-        'decoder': OrderedDict(),
-        'src_emb': OrderedDict({
-            ('a',): (0, 'Group 0 with GPU ranks [0, 1]'),
-        }),
-        'tgt_emb': OrderedDict(),
-        'encoder_adapters': OrderedDict(),
-        'decoder_adapters': OrderedDict(),
-    }
+    my_components = task_queue_manager.get_my_distributed_components()
+    for component in my_components:
+        if component not in all_components:
+            raise Exception(f'my component {component} not in all_components {all_components}')
+    assert my_components == [
+        DistributedEncoder(
+            global_ranks={0, 1}, group='Group 0 with GPU ranks [0, 1]', layer_stack_index=0, xcoder_id='x'
+        ),
+        DistributedEncoder(global_ranks={1}, group=None, layer_stack_index=0, xcoder_id='xx'),
+        DistributedDecoder(global_ranks={1}, group=None, layer_stack_index=0, xcoder_id='yy'),
+        DistributedGenerator(global_ranks={1}, group=None, lang='d'),
+        DistributedEmbedding(global_ranks={0, 1}, group='Group 3 with GPU ranks [0, 1]', side=Side.encoder, lang='a'),
+        DistributedEmbedding(global_ranks={1}, group=None, side=Side.encoder, lang='c'),
+        DistributedEmbedding(global_ranks={1}, group=None, side=Side.decoder, lang='d'),
+    ]
 
 
 def test_cpu_distributed_groups():
     opt_dict = {
+        'seed': 42,
         'accum_count': 4,
         'task_distribution_strategy': 'roundrobin',
         'world_size': 0,
@@ -192,25 +216,31 @@ def test_cpu_distributed_groups():
                 'path_tgt': 'dummy',
                 'src_tgt': 'c-d',
             },
-        }
+        },
     }
     opts = Namespace(**opt_dict)
     world_context = WorldContext.from_opts(opts)
     global_task_queue_manager = TaskQueueManager.from_opts(opts, world_context)
-    task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=0, opts=opts)
     new_group_func = MagicMock().new_group_func
-    my_groups = task_queue_manager.get_my_distributed_groups(new_group_func=new_group_func)
+    all_components = global_task_queue_manager.create_all_distributed_components(
+        use_attention_bridge=False,
+        new_group_func=new_group_func,
+    )
+    task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=0, opts=opts)
+    my_components = task_queue_manager.get_my_distributed_components()
     # No groups should be created when running on CPU
     new_group_func.assert_not_called()
-    # The component keys should still exist, but be empty
-    for component in ['encoder', 'decoder', 'src_emb', 'tgt_emb']:
-        assert len(my_groups[component]) == 0
+    for component in all_components:
+        assert component.group is None
+    for component in my_components:
+        assert component.group is None
     assert not world_context.is_gpu()
     assert not world_context.is_distributed()
 
 
 def test_distributed_groups_no_encoder_group():
     opt_dict = {
+        'seed': 42,
         'accum_count': 1,
         'task_distribution_strategy': 'roundrobin',
         'world_size': 4,
@@ -244,47 +274,28 @@ def test_distributed_groups_no_encoder_group():
                 'src_tgt': 'd-c',
                 'node_gpu': '1:1',
             },
-        }
+        },
     }
     opts = Namespace(**opt_dict)
     world_context = WorldContext.from_opts(opts)
     global_task_queue_manager = TaskQueueManager.from_opts(opts, world_context)
-    task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=0, opts=opts)
     new_group_func = MagicMock().new_group_func
-    my_groups = task_queue_manager.get_my_distributed_groups(new_group_func=new_group_func)
+    all_components = global_task_queue_manager.create_all_distributed_components(
+        use_attention_bridge=False,
+        new_group_func=new_group_func,
+    )
+    task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=0, opts=opts)
+    my_components = task_queue_manager.get_my_distributed_components()
+
     # No groups should be created:
     # AB is fully shared (doesn't need a group),
     # and all other components are not shared at all
     new_group_func.assert_not_called()
-    # The component keys should still exist, but be empty
-    for component in ['encoder', 'decoder', 'src_emb', 'tgt_emb']:
-        assert len(my_groups[component]) == 0
-
-
-# FIXME
-# def test_get_fields():
-#     mock_fields = {
-#         (side, lang): f'{side} {lang}' for (side, lang) in
-#         [('src', 'a'), ('src', 'c'), ('src', 'e'), ('tgt', 'b'), ('tgt', 'd')]
-#     }
-#     global_task_queue_manager, opts = create_basic_task_queue_manager()
-#     task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=0, opts=opts)
-#     fields = task_queue_manager.get_fields('src', mock_fields)
-#     assert fields == [('src', 'a', None, 'src a')]
-#     fields = task_queue_manager.get_fields('tgt', mock_fields)
-#     assert fields == [('tgt', 'b', None, 'tgt b')]
-#
-#     task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=1, opts=opts)
-#     fields = task_queue_manager.get_fields('src', mock_fields)
-#     assert fields == [('src', 'c', None, 'src c'), ('src', 'a', 'x', 'src a')]
-#     fields = task_queue_manager.get_fields('tgt', mock_fields)
-#     assert fields == [('tgt', 'd', None, 'tgt d')]
-#
-#     task_queue_manager = global_task_queue_manager.global_to_local(node_rank=1, local_rank=0, opts=opts)
-#     fields = task_queue_manager.get_fields('src', mock_fields)
-#     assert fields == [('src', 'e', None, 'src e')]
-#     fields = task_queue_manager.get_fields('tgt', mock_fields)
-#     assert fields == [('tgt', 'b', None, 'tgt b')]
+    for component in all_components:
+        assert component.group is None
+    for component in my_components:
+        assert component.group is None
+    assert len(my_components) > 0
 
 
 def test_basic_getters():
@@ -312,3 +323,112 @@ def test_basic_getters():
     assert tgt_langs == ['d', 'd']
     generators = list(task_queue_manager.get_my_generators())
     assert generators == ['d', 'd']
+
+
+def create_sampling_task_queue_manager(tasks):
+    opt_dict = {
+        'seed': 1024,
+        'accum_count': 8,
+        'task_distribution_strategy': 'weighted_sampling',
+        'world_size': 4,
+        'n_nodes': 2,
+        'gpu_ranks': [0, 1],
+        'enc_layers': [1],
+        'dec_layers': [1],
+        # node_gpu unconventional assignment: two on 0:1, none on 1:1
+        # enc_sharing_group x is twice, on two devices 0:0 and 0:1
+        # dec_sharing_group y is twice, on two devices 0:0 and 1:0
+        # dec_sharing_group yy is twice, but only on a single device 0:1
+        'tasks': tasks,
+    }
+    opts = Namespace(**opt_dict)
+    world_context = WorldContext.from_opts(opts)
+    task_queue_manager = TaskQueueManager.from_opts(opts, world_context)
+    # create all local TQM:s, in order to validate
+    for node_rank in range(task_queue_manager.n_nodes):
+        for local_rank in range(task_queue_manager.gpus_per_node):
+            task_queue_manager.global_to_local(node_rank, local_rank, opts)
+    return task_queue_manager, opts
+
+
+def test_weights_all_zero():
+    with pytest.raises(ValueError) as exc_info:
+        task_queue_manager, opts = create_sampling_task_queue_manager(
+            tasks={
+                'a': {
+                    'src_tgt': 'a-b',
+                    'node_gpu': '0:0',
+                    'weight': 0,
+                    'introduce_at_training_step': 0,
+                },
+                'b': {
+                    'src_tgt': 'a-b',
+                    'node_gpu': '0:0',
+                    'weight': 0,
+                    'introduce_at_training_step': 0,
+                },
+                'notmine': {
+                    'src_tgt': 'a-b',
+                    'node_gpu': '0:1',
+                    'weight': 10,
+                    'introduce_at_training_step': 0,
+                },
+            }
+        )
+    assert 'Can not set "weight" of all corpora on a device to zero' in str(exc_info.value)
+
+
+def test_weights_all_postponed():
+    with pytest.raises(ValueError) as exc_info:
+        task_queue_manager, opts = create_sampling_task_queue_manager(
+            tasks={
+                'a': {
+                    'src_tgt': 'a-b',
+                    'node_gpu': '0:0',
+                    'weight': 1,
+                    'introduce_at_training_step': 1,
+                },
+                'b': {
+                    'src_tgt': 'a-b',
+                    'node_gpu': '0:0',
+                    'weight': 1,
+                    'introduce_at_training_step': 10,
+                },
+                'notmine': {
+                    'src_tgt': 'a-b',
+                    'node_gpu': '0:1',
+                    'weight': 10,
+                    'introduce_at_training_step': 0,
+                },
+            }
+        )
+    assert 'Can not set "introduce_at_training_step" of all corpora on a device to nonzero' in str(exc_info.value)
+
+
+def test_invalid_curriculum():
+    with pytest.raises(ValueError) as exc_info:
+        task_queue_manager, opts = create_sampling_task_queue_manager(
+            tasks={
+                # 'a' disabled by weight
+                'a': {
+                    'src_tgt': 'a-b',
+                    'node_gpu': '0:0',
+                    'weight': 0,
+                    'introduce_at_training_step': 0,
+                },
+                # 'b' postponed
+                'b': {
+                    'src_tgt': 'a-b',
+                    'node_gpu': '0:0',
+                    'weight': 1,
+                    'introduce_at_training_step': 10,
+                },
+                'notmine': {
+                    'src_tgt': 'a-b',
+                    'node_gpu': '0:1',
+                    'weight': 10,
+                    'introduce_at_training_step': 0,
+                },
+            }
+        )
+    assert 'Invalid curriculum' in str(exc_info.value)

--- a/mammoth/tests/test_task_queue_manager.py
+++ b/mammoth/tests/test_task_queue_manager.py
@@ -18,17 +18,17 @@ from mammoth.distributed.components import (
 
 def test_init_minimal():
     opt_dict = {
-        'seed': 1024,
-        'accum_count': 1,
-        'task_distribution_strategy': 'roundrobin',
-        'world_size': 2,
-        'n_nodes': 1,
-        'gpu_ranks': [0, 1],
-        'enc_layers': [1],
-        'dec_layers': [1],
-        'tasks': {
-            'train_a-b': {'path_src': 'dummy', 'path_tgt': 'dummy', 'src_tgt': 'a-b'},
-            'train_c-d': {'path_src': 'dummy', 'path_tgt': 'dummy', 'src_tgt': 'c-d'},
+        "seed": 1024,
+        "accum_count": 1,
+        "task_distribution_strategy": "roundrobin",
+        "world_size": 2,
+        "n_nodes": 1,
+        "gpu_ranks": [0, 1],
+        "enc_layers": [1],
+        "dec_layers": [1],
+        "tasks": {
+            "train_a-b": {"path_src": "dummy", "path_tgt": "dummy", "src_tgt": "a-b"},
+            "train_c-d": {"path_src": "dummy", "path_tgt": "dummy", "src_tgt": "c-d"},
         },
     }
     opts = Namespace(**opt_dict)
@@ -50,58 +50,58 @@ def test_init_minimal():
 
 def create_basic_task_queue_manager():
     opt_dict = {
-        'seed': 1024,
-        'accum_count': 8,
-        'task_distribution_strategy': 'weighted_sampling',
-        'world_size': 4,
-        'n_nodes': 2,
-        'gpu_ranks': [0, 1],
-        'enc_layers': [1],
-        'dec_layers': [1],
+        "seed": 1024,
+        "accum_count": 8,
+        "task_distribution_strategy": "weighted_sampling",
+        "world_size": 4,
+        "n_nodes": 2,
+        "gpu_ranks": [0, 1],
+        "enc_layers": [1],
+        "dec_layers": [1],
         # node_gpu unconventional assignment: two on 0:1, none on 1:1
         # enc_sharing_group x is twice, on two devices 0:0 and 0:1
         # dec_sharing_group y is twice, on two devices 0:0 and 1:0
         # dec_sharing_group yy is twice, but only on a single device 0:1
-        'tasks': {
-            'train_0_a-b': {
-                'path_src': 'dummy',
-                'path_tgt': 'dummy',
-                'weight': 2,
-                'introduce_at_training_step': 0,
-                'src_tgt': 'a-b',
-                'node_gpu': '0:0',
-                'enc_sharing_group': ['x'],
-                'dec_sharing_group': ['y'],
+        "tasks": {
+            "train_0_a-b": {
+                "path_src": "dummy",
+                "path_tgt": "dummy",
+                "weight": 2,
+                "introduce_at_training_step": 0,
+                "src_tgt": "a-b",
+                "node_gpu": "0:0",
+                "enc_sharing_group": ["x"],
+                "dec_sharing_group": ["y"],
             },
-            'train_2_a-d': {
-                'path_src': 'dummy',
-                'path_tgt': 'dummy',
-                'weight': 1,
-                'introduce_at_training_step': 10,
-                'src_tgt': 'a-d',
-                'node_gpu': '0:1',
-                'enc_sharing_group': ['x'],
-                'dec_sharing_group': ['yy'],
+            "train_2_a-d": {
+                "path_src": "dummy",
+                "path_tgt": "dummy",
+                "weight": 1,
+                "introduce_at_training_step": 10,
+                "src_tgt": "a-d",
+                "node_gpu": "0:1",
+                "enc_sharing_group": ["x"],
+                "dec_sharing_group": ["yy"],
             },
-            'train_3_e-b': {
-                'path_src': 'dummy',
-                'path_tgt': 'dummy',
-                'weight': 1,
-                'introduce_at_training_step': 0,
-                'src_tgt': 'e-b',
-                'node_gpu': '1:0',
-                'enc_sharing_group': ['xxx'],
-                'dec_sharing_group': ['y'],
+            "train_3_e-b": {
+                "path_src": "dummy",
+                "path_tgt": "dummy",
+                "weight": 1,
+                "introduce_at_training_step": 0,
+                "src_tgt": "e-b",
+                "node_gpu": "1:0",
+                "enc_sharing_group": ["xxx"],
+                "dec_sharing_group": ["y"],
             },
-            'train_1_c-d': {
-                'path_src': 'dummy',
-                'path_tgt': 'dummy',
-                'weight': 1,
-                'introduce_at_training_step': 0,
-                'src_tgt': 'c-d',
-                'node_gpu': '0:1',
-                'enc_sharing_group': ['xx'],
-                'dec_sharing_group': ['yy'],
+            "train_1_c-d": {
+                "path_src": "dummy",
+                "path_tgt": "dummy",
+                "weight": 1,
+                "introduce_at_training_step": 0,
+                "src_tgt": "c-d",
+                "node_gpu": "0:1",
+                "enc_sharing_group": ["xx"],
+                "dec_sharing_group": ["yy"],
             },
         },
     }
@@ -113,7 +113,9 @@ def create_basic_task_queue_manager():
 
 def test_init_basic():
     global_task_queue_manager, opts = create_basic_task_queue_manager()
-    task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=1, opts=opts)
+    task_queue_manager = global_task_queue_manager.global_to_local(
+        node_rank=0, local_rank=1, opts=opts
+    )
     world_context = task_queue_manager.world_context
     assert world_context.is_gpu()
     assert world_context.is_distributed()
@@ -123,10 +125,20 @@ def test_init_basic():
     assert task_queue_manager.node_rank == 0
     assert task_queue_manager.local_rank == 1
     # accessing task_queue_manager data structures directly: not filtered by rank
-    assert [task.encoder_id for task in task_queue_manager.tasks] == [['x'], ['xx'], ['x'], ['xxx']]
-    assert [task.decoder_id for task in task_queue_manager.tasks] == [['y'], ['yy'], ['yy'], ['y']]
-    assert [task.src_lang for task in task_queue_manager.tasks] == ['a', 'c', 'a', 'e']
-    assert [task.tgt_lang for task in task_queue_manager.tasks] == ['b', 'd', 'd', 'b']
+    assert [task.encoder_id for task in task_queue_manager.tasks] == [
+        ["x"],
+        ["xx"],
+        ["x"],
+        ["xxx"],
+    ]
+    assert [task.decoder_id for task in task_queue_manager.tasks] == [
+        ["y"],
+        ["yy"],
+        ["yy"],
+        ["y"],
+    ]
+    assert [task.src_lang for task in task_queue_manager.tasks] == ["a", "c", "a", "e"]
+    assert [task.tgt_lang for task in task_queue_manager.tasks] == ["b", "d", "d", "b"]
 
 
 def test_create_all_distributed_components():
@@ -135,7 +147,7 @@ def test_create_all_distributed_components():
             self.group_idx = 0
 
         def __call__(self, sorted_global_ranks):
-            result = f'Group {self.group_idx} with GPU ranks {sorted_global_ranks}'
+            result = f"Group {self.group_idx} with GPU ranks {sorted_global_ranks}"
             self.group_idx += 1
             return result
 
@@ -145,21 +157,79 @@ def test_create_all_distributed_components():
     )
     assert all_components == [
         DistributedDecoder(
-            global_ranks={0, 2}, group='Group 0 with GPU ranks [0, 2]', layer_stack_index=0, xcoder_id='y'
+            global_ranks={0, 2},
+            task_ids={'train_3_e-b', 'train_0_a-b'},
+            group="Group 0 with GPU ranks [0, 2]",
+            layer_stack_index=0,
+            xcoder_id="y",
         ),
-        DistributedDecoder(global_ranks={1}, group=None, layer_stack_index=0, xcoder_id='yy'),
+        DistributedDecoder(
+            global_ranks={1},
+            task_ids={"train_2_a-d", "train_1_c-d"},
+            group=None,
+            layer_stack_index=0,
+            xcoder_id="yy",
+        ),
         DistributedEncoder(
-            global_ranks={0, 1}, group='Group 1 with GPU ranks [0, 1]', layer_stack_index=0, xcoder_id='x'
+            global_ranks={0, 1},
+            task_ids={"train_2_a-d", "train_0_a-b"},
+            group="Group 1 with GPU ranks [0, 1]",
+            layer_stack_index=0,
+            xcoder_id="x",
         ),
-        DistributedEncoder(global_ranks={1}, group=None, layer_stack_index=0, xcoder_id='xx'),
-        DistributedEncoder(global_ranks={2}, group=None, layer_stack_index=0, xcoder_id='xxx'),
-        DistributedGenerator(global_ranks={0, 2}, group='Group 2 with GPU ranks [0, 2]', lang='b'),
-        DistributedGenerator(global_ranks={1}, group=None, lang='d'),
-        DistributedEmbedding(global_ranks={0, 1}, group='Group 3 with GPU ranks [0, 1]', side=Side.encoder, lang='a'),
-        DistributedEmbedding(global_ranks={1}, group=None, side=Side.encoder, lang='c'),
-        DistributedEmbedding(global_ranks={2}, group=None, side=Side.encoder, lang='e'),
-        DistributedEmbedding(global_ranks={0, 2}, group='Group 4 with GPU ranks [0, 2]', side=Side.decoder, lang='b'),
-        DistributedEmbedding(global_ranks={1}, group=None, side=Side.decoder, lang='d'),
+        DistributedEncoder(
+            global_ranks={1},
+            task_ids={"train_1_c-d"},
+            group=None,
+            layer_stack_index=0,
+            xcoder_id="xx",
+        ),
+        DistributedEncoder(
+            global_ranks={2},
+            task_ids={'train_3_e-b'},
+            group=None,
+            layer_stack_index=0,
+            xcoder_id="xxx",
+        ),
+        DistributedGenerator(
+            global_ranks={0, 2},
+            task_ids={'train_3_e-b', 'train_0_a-b'},
+            group="Group 2 with GPU ranks [0, 2]",
+            lang="b",
+        ),
+        DistributedGenerator(
+            global_ranks={1},
+            task_ids={"train_2_a-d", "train_1_c-d"},
+            group=None,
+            lang="d",
+        ),
+        DistributedEmbedding(
+            global_ranks={0, 1},
+            task_ids={"train_0_a-b", "train_2_a-d"},
+            group="Group 3 with GPU ranks [0, 1]",
+            side=Side.encoder,
+            lang="a",
+        ),
+        DistributedEmbedding(
+            global_ranks={1}, task_ids={"train_1_c-d"}, group=None, side=Side.encoder, lang="c"
+        ),
+        DistributedEmbedding(
+            global_ranks={2}, task_ids={'train_3_e-b'}, group=None, side=Side.encoder, lang="e"
+        ),
+        DistributedEmbedding(
+            global_ranks={0, 2},
+            task_ids={'train_3_e-b', 'train_0_a-b'},
+            group="Group 4 with GPU ranks [0, 2]",
+            side=Side.decoder,
+            lang="b",
+        ),
+        DistributedEmbedding(
+            global_ranks={1},
+            task_ids={"train_2_a-d", "train_1_c-d"},
+            group=None,
+            side=Side.decoder,
+            lang="d",
+        ),
     ]
 
 
@@ -169,7 +239,7 @@ def test_get_my_distributed_components():
             self.group_idx = 0
 
         def __call__(self, sorted_global_ranks):
-            result = f'Group {self.group_idx} with GPU ranks {sorted_global_ranks}'
+            result = f"Group {self.group_idx} with GPU ranks {sorted_global_ranks}"
             self.group_idx += 1
             return result
 
@@ -177,44 +247,87 @@ def test_get_my_distributed_components():
     all_components = global_task_queue_manager.create_all_distributed_components(
         use_attention_bridge=False, new_group_func=MockGroup()
     )
-    task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=1, opts=opts)
+    task_queue_manager = global_task_queue_manager.global_to_local(
+        node_rank=0, local_rank=1, opts=opts
+    )
     my_components = task_queue_manager.get_my_distributed_components()
     for component in my_components:
         if component not in all_components:
-            raise Exception(f'my component {component} not in all_components {all_components}')
+            raise Exception(
+                f"my component {component} not in all_components {all_components}"
+            )
     assert my_components == [
-        DistributedDecoder(global_ranks={1}, group=None, layer_stack_index=0, xcoder_id='yy'),
-        DistributedEncoder(
-            global_ranks={0, 1}, group='Group 1 with GPU ranks [0, 1]', layer_stack_index=0, xcoder_id='x'
+        DistributedDecoder(
+            global_ranks={1},
+            task_ids={"train_2_a-d", "train_1_c-d"},
+            group=None,
+            layer_stack_index=0,
+            xcoder_id="yy",
         ),
-        DistributedEncoder(global_ranks={1}, group=None, layer_stack_index=0, xcoder_id='xx'),
-        DistributedGenerator(global_ranks={1}, group=None, lang='d'),
-        DistributedEmbedding(global_ranks={0, 1}, group='Group 3 with GPU ranks [0, 1]', side=Side.encoder, lang='a'),
-        DistributedEmbedding(global_ranks={1}, group=None, side=Side.encoder, lang='c'),
-        DistributedEmbedding(global_ranks={1}, group=None, side=Side.decoder, lang='d'),
+        DistributedEncoder(
+            global_ranks={0, 1},
+            task_ids={"train_2_a-d", "train_0_a-b"},
+            group="Group 1 with GPU ranks [0, 1]",
+            layer_stack_index=0,
+            xcoder_id="x",
+        ),
+        DistributedEncoder(
+            global_ranks={1},
+            task_ids={"train_1_c-d"},
+            group=None,
+            layer_stack_index=0,
+            xcoder_id="xx",
+        ),
+        DistributedGenerator(
+            global_ranks={1},
+            task_ids={"train_2_a-d", "train_1_c-d"},
+            group=None,
+            lang="d",
+        ),
+        DistributedEmbedding(
+            global_ranks={0, 1},
+            task_ids={"train_0_a-b", "train_2_a-d"},
+            group="Group 3 with GPU ranks [0, 1]",
+            side=Side.encoder,
+            lang="a",
+        ),
+        DistributedEmbedding(
+            global_ranks={1},
+            task_ids={"train_1_c-d"},
+            group=None,
+            side=Side.encoder,
+            lang="c",
+        ),
+        DistributedEmbedding(
+            global_ranks={1},
+            task_ids={"train_2_a-d", "train_1_c-d"},
+            group=None,
+            side=Side.decoder,
+            lang="d",
+        ),
     ]
 
 
 def test_cpu_distributed_groups():
     opt_dict = {
-        'seed': 42,
-        'accum_count': 4,
-        'task_distribution_strategy': 'roundrobin',
-        'world_size': 0,
-        'gpu_ranks': [],
-        'n_nodes': 1,
-        'enc_layers': [1],
-        'dec_layers': [1],
-        'tasks': {
-            'train_a-b': {
-                'path_src': 'dummy',
-                'path_tgt': 'dummy',
-                'src_tgt': 'a-b',
+        "seed": 42,
+        "accum_count": 4,
+        "task_distribution_strategy": "roundrobin",
+        "world_size": 0,
+        "gpu_ranks": [],
+        "n_nodes": 1,
+        "enc_layers": [1],
+        "dec_layers": [1],
+        "tasks": {
+            "train_a-b": {
+                "path_src": "dummy",
+                "path_tgt": "dummy",
+                "src_tgt": "a-b",
             },
-            'train_c-d': {
-                'path_src': 'dummy',
-                'path_tgt': 'dummy',
-                'src_tgt': 'c-d',
+            "train_c-d": {
+                "path_src": "dummy",
+                "path_tgt": "dummy",
+                "src_tgt": "c-d",
             },
         },
     }
@@ -226,7 +339,9 @@ def test_cpu_distributed_groups():
         use_attention_bridge=False,
         new_group_func=new_group_func,
     )
-    task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=0, opts=opts)
+    task_queue_manager = global_task_queue_manager.global_to_local(
+        node_rank=0, local_rank=0, opts=opts
+    )
     my_components = task_queue_manager.get_my_distributed_components()
     # No groups should be created when running on CPU
     new_group_func.assert_not_called()
@@ -240,39 +355,39 @@ def test_cpu_distributed_groups():
 
 def test_distributed_groups_no_encoder_group():
     opt_dict = {
-        'seed': 42,
-        'accum_count': 1,
-        'task_distribution_strategy': 'roundrobin',
-        'world_size': 4,
-        'n_nodes': 2,
-        'enc_layers': [1],
-        'dec_layers': [1],
-        'gpu_ranks': [0, 1],
+        "seed": 42,
+        "accum_count": 1,
+        "task_distribution_strategy": "roundrobin",
+        "world_size": 4,
+        "n_nodes": 2,
+        "enc_layers": [1],
+        "dec_layers": [1],
+        "gpu_ranks": [0, 1],
         # every language pair on its own gpu: no overlap
-        'tasks': {
-            'train_a-b': {
-                'path_src': 'dummy',
-                'path_tgt': 'dummy',
-                'src_tgt': 'a-b',
-                'node_gpu': '0:0',
+        "tasks": {
+            "train_a-b": {
+                "path_src": "dummy",
+                "path_tgt": "dummy",
+                "src_tgt": "a-b",
+                "node_gpu": "0:0",
             },
-            'train_c-d': {
-                'path_src': 'dummy',
-                'path_tgt': 'dummy',
-                'src_tgt': 'c-d',
-                'node_gpu': '0:1',
+            "train_c-d": {
+                "path_src": "dummy",
+                "path_tgt": "dummy",
+                "src_tgt": "c-d",
+                "node_gpu": "0:1",
             },
-            'train_b-a': {
-                'path_src': 'dummy',
-                'path_tgt': 'dummy',
-                'src_tgt': 'b-a',
-                'node_gpu': '1:0',
+            "train_b-a": {
+                "path_src": "dummy",
+                "path_tgt": "dummy",
+                "src_tgt": "b-a",
+                "node_gpu": "1:0",
             },
-            'train_d-c': {
-                'path_src': 'dummy',
-                'path_tgt': 'dummy',
-                'src_tgt': 'd-c',
-                'node_gpu': '1:1',
+            "train_d-c": {
+                "path_src": "dummy",
+                "path_tgt": "dummy",
+                "src_tgt": "d-c",
+                "node_gpu": "1:1",
             },
         },
     }
@@ -284,7 +399,9 @@ def test_distributed_groups_no_encoder_group():
         use_attention_bridge=False,
         new_group_func=new_group_func,
     )
-    task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=0, opts=opts)
+    task_queue_manager = global_task_queue_manager.global_to_local(
+        node_rank=0, local_rank=0, opts=opts
+    )
     my_components = task_queue_manager.get_my_distributed_components()
 
     # No groups should be created:
@@ -300,46 +417,50 @@ def test_distributed_groups_no_encoder_group():
 
 def test_basic_getters():
     global_task_queue_manager, opts = create_basic_task_queue_manager()
-    task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=0, opts=opts)
+    task_queue_manager = global_task_queue_manager.global_to_local(
+        node_rank=0, local_rank=0, opts=opts
+    )
     encoders = list(task_queue_manager.get_my_encoders(0))
-    assert encoders == ['x']
+    assert encoders == ["x"]
     decoders = list(task_queue_manager.get_my_decoders(0))
-    assert decoders == ['y']
+    assert decoders == ["y"]
     src_langs = list(task_queue_manager.get_my_src_langs())
-    assert src_langs == ['a']
+    assert src_langs == ["a"]
     tgt_langs = list(task_queue_manager.get_my_tgt_langs())
-    assert tgt_langs == ['b']
+    assert tgt_langs == ["b"]
     generators = list(task_queue_manager.get_my_generators())
-    assert generators == ['b']
+    assert generators == ["b"]
 
-    task_queue_manager = global_task_queue_manager.global_to_local(node_rank=0, local_rank=1, opts=opts)
+    task_queue_manager = global_task_queue_manager.global_to_local(
+        node_rank=0, local_rank=1, opts=opts
+    )
     encoders = list(task_queue_manager.get_my_encoders(0))
-    assert encoders == ['xx', 'x']
+    assert encoders == ["xx", "x"]
     decoders = list(task_queue_manager.get_my_decoders(0))
-    assert decoders == ['yy', 'yy']
+    assert decoders == ["yy", "yy"]
     src_langs = list(task_queue_manager.get_my_src_langs())
-    assert src_langs == ['c', 'a']
+    assert src_langs == ["c", "a"]
     tgt_langs = list(task_queue_manager.get_my_tgt_langs())
-    assert tgt_langs == ['d', 'd']
+    assert tgt_langs == ["d", "d"]
     generators = list(task_queue_manager.get_my_generators())
-    assert generators == ['d', 'd']
+    assert generators == ["d", "d"]
 
 
 def create_sampling_task_queue_manager(tasks):
     opt_dict = {
-        'seed': 1024,
-        'accum_count': 8,
-        'task_distribution_strategy': 'weighted_sampling',
-        'world_size': 4,
-        'n_nodes': 2,
-        'gpu_ranks': [0, 1],
-        'enc_layers': [1],
-        'dec_layers': [1],
+        "seed": 1024,
+        "accum_count": 8,
+        "task_distribution_strategy": "weighted_sampling",
+        "world_size": 4,
+        "n_nodes": 2,
+        "gpu_ranks": [0, 1],
+        "enc_layers": [1],
+        "dec_layers": [1],
         # node_gpu unconventional assignment: two on 0:1, none on 1:1
         # enc_sharing_group x is twice, on two devices 0:0 and 0:1
         # dec_sharing_group y is twice, on two devices 0:0 and 1:0
         # dec_sharing_group yy is twice, but only on a single device 0:1
-        'tasks': tasks,
+        "tasks": tasks,
     }
     opts = Namespace(**opt_dict)
     world_context = WorldContext.from_opts(opts)
@@ -355,54 +476,59 @@ def test_weights_all_zero():
     with pytest.raises(ValueError) as exc_info:
         task_queue_manager, opts = create_sampling_task_queue_manager(
             tasks={
-                'a': {
-                    'src_tgt': 'a-b',
-                    'node_gpu': '0:0',
-                    'weight': 0,
-                    'introduce_at_training_step': 0,
+                "a": {
+                    "src_tgt": "a-b",
+                    "node_gpu": "0:0",
+                    "weight": 0,
+                    "introduce_at_training_step": 0,
                 },
-                'b': {
-                    'src_tgt': 'a-b',
-                    'node_gpu': '0:0',
-                    'weight': 0,
-                    'introduce_at_training_step': 0,
+                "b": {
+                    "src_tgt": "a-b",
+                    "node_gpu": "0:0",
+                    "weight": 0,
+                    "introduce_at_training_step": 0,
                 },
-                'notmine': {
-                    'src_tgt': 'a-b',
-                    'node_gpu': '0:1',
-                    'weight': 10,
-                    'introduce_at_training_step': 0,
+                "notmine": {
+                    "src_tgt": "a-b",
+                    "node_gpu": "0:1",
+                    "weight": 10,
+                    "introduce_at_training_step": 0,
                 },
             }
         )
-    assert 'Can not set "weight" of all corpora on a device to zero' in str(exc_info.value)
+    assert 'Can not set "weight" of all corpora on a device to zero' in str(
+        exc_info.value
+    )
 
 
 def test_weights_all_postponed():
     with pytest.raises(ValueError) as exc_info:
         task_queue_manager, opts = create_sampling_task_queue_manager(
             tasks={
-                'a': {
-                    'src_tgt': 'a-b',
-                    'node_gpu': '0:0',
-                    'weight': 1,
-                    'introduce_at_training_step': 1,
+                "a": {
+                    "src_tgt": "a-b",
+                    "node_gpu": "0:0",
+                    "weight": 1,
+                    "introduce_at_training_step": 1,
                 },
-                'b': {
-                    'src_tgt': 'a-b',
-                    'node_gpu': '0:0',
-                    'weight': 1,
-                    'introduce_at_training_step': 10,
+                "b": {
+                    "src_tgt": "a-b",
+                    "node_gpu": "0:0",
+                    "weight": 1,
+                    "introduce_at_training_step": 10,
                 },
-                'notmine': {
-                    'src_tgt': 'a-b',
-                    'node_gpu': '0:1',
-                    'weight': 10,
-                    'introduce_at_training_step': 0,
+                "notmine": {
+                    "src_tgt": "a-b",
+                    "node_gpu": "0:1",
+                    "weight": 10,
+                    "introduce_at_training_step": 0,
                 },
             }
         )
-    assert 'Can not set "introduce_at_training_step" of all corpora on a device to nonzero' in str(exc_info.value)
+    assert (
+        'Can not set "introduce_at_training_step" of all corpora on a device to nonzero'
+        in str(exc_info.value)
+    )
 
 
 def test_invalid_curriculum():
@@ -410,25 +536,25 @@ def test_invalid_curriculum():
         task_queue_manager, opts = create_sampling_task_queue_manager(
             tasks={
                 # 'a' disabled by weight
-                'a': {
-                    'src_tgt': 'a-b',
-                    'node_gpu': '0:0',
-                    'weight': 0,
-                    'introduce_at_training_step': 0,
+                "a": {
+                    "src_tgt": "a-b",
+                    "node_gpu": "0:0",
+                    "weight": 0,
+                    "introduce_at_training_step": 0,
                 },
                 # 'b' postponed
-                'b': {
-                    'src_tgt': 'a-b',
-                    'node_gpu': '0:0',
-                    'weight': 1,
-                    'introduce_at_training_step': 10,
+                "b": {
+                    "src_tgt": "a-b",
+                    "node_gpu": "0:0",
+                    "weight": 1,
+                    "introduce_at_training_step": 10,
                 },
-                'notmine': {
-                    'src_tgt': 'a-b',
-                    'node_gpu': '0:1',
-                    'weight': 10,
-                    'introduce_at_training_step': 0,
+                "notmine": {
+                    "src_tgt": "a-b",
+                    "node_gpu": "0:1",
+                    "weight": 10,
+                    "introduce_at_training_step": 0,
                 },
             }
         )
-    assert 'Invalid curriculum' in str(exc_info.value)
+    assert "Invalid curriculum" in str(exc_info.value)

--- a/mammoth/train_single.py
+++ b/mammoth/train_single.py
@@ -57,7 +57,7 @@ def _build_valid_iter(opts, vocabs_dict, transforms_cls, task_queue_manager):
 
 
 def init_distributed(model, task_queue_manager):
-    my_component_groups = task_queue_manager.get_distributed_groups()
+    my_component_groups = task_queue_manager.get_my_distributed_groups()
     for (layer_stack_index, encoder_id), (min_rank, group) in my_component_groups['encoder'].items():
         weights = [
             p.data for name, p
@@ -143,7 +143,7 @@ def main(
         init_distributed(model, task_queue_manager)
     else:
         # Initialize some data structures
-        _ = task_queue_manager.get_distributed_groups()
+        _ = task_queue_manager.get_my_distributed_groups()
     enc, dec = model.count_parameters(log=logger.debug)
     logger.info("{} - total encoder parameters: {}".format(device_context.id, enc))
     logger.info("{} - total decoder parameters: {}".format(device_context.id, dec))

--- a/mammoth/trainer.py
+++ b/mammoth/trainer.py
@@ -57,7 +57,7 @@ def build_trainer(
     valid_loss_md = nn.ModuleDict()
     logger.info("BUILD TRAINER")
 
-    for (side, lang, component_id, tgt_vocab) in task_queue_manager.get_vocabs('tgt', vocabs_dict):
+    for (side, lang, component_id, tgt_vocab) in task_queue_manager.get_my_vocabs('tgt', vocabs_dict):
         generator = generators_md[f'generator_{lang}']
         train_loss_md.add_module(
             f'trainloss{lang}',
@@ -190,7 +190,7 @@ class Trainer(object):
         self.dropout_steps = dropout_steps
 
         self.task_queue_manager = task_queue_manager
-        my_component_groups = self.task_queue_manager.get_distributed_groups()
+        my_component_groups = self.task_queue_manager.get_my_distributed_groups()
         self.my_encoder_groups = my_component_groups['encoder']
         self.my_decoder_groups = my_component_groups['decoder']
         self.my_src_emb_groups = my_component_groups['src_emb']

--- a/mammoth/trainer.py
+++ b/mammoth/trainer.py
@@ -270,7 +270,6 @@ class Trainer(object):
             batches_with_meta = islice(train_iter, self.accum_count)
 
             batch_task_sample = self.task_queue_manager.sample_corpus_ids()
-            logger.info(f'batch_task_sample has {batch_task_sample.training_step}')
             my_task = batch_task_sample.tasks[self.task_queue_manager.global_rank]
 
             self._gradient_accumulation(

--- a/mammoth/trainer.py
+++ b/mammoth/trainer.py
@@ -460,6 +460,9 @@ class Trainer(object):
             # cf. `onmt.utils.loss.CommonLossCompute._make_shard_state`
             tgt_outer = batch.tgt
 
+            # QUI logging for batch shapes
+            # print(src.shape, src.shape[0] * src.shape[1], tgt_outer.shape, tgt_outer.shape[0] * tgt_outer.shape[1])
+
             bptt = False
             for j in range(0, target_size - 1, trunc_size):
                 # 1. Create truncated target.

--- a/mammoth/utils/misc.py
+++ b/mammoth/utils/misc.py
@@ -96,7 +96,7 @@ def set_random_seed(seed, is_cuda):
         # some cudnn methods can be random even after fixing the seed
         # unless you tell it to be deterministic
         torch.backends.cudnn.deterministic = True
-        # This one is needed for various tranfroms
+        # This one is needed for various transforms
         np.random.seed(seed)
 
     if is_cuda and seed > 0:

--- a/mammoth/utils/optimizers.py
+++ b/mammoth/utils/optimizers.py
@@ -14,7 +14,7 @@ from mammoth.utils.logging import logger
 
 def attention_bridge_optimizer(model, task_queue_manager, base_optimizer):
     suboptimizers = {}
-    my_grouped_components = task_queue_manager.get_grouped_components(model)
+    my_grouped_components = task_queue_manager.get_my_grouped_components(model)
     for component_type in my_grouped_components:
         for component_id, component in my_grouped_components[component_type].items():
             if isinstance(component_id, str):
@@ -37,7 +37,7 @@ def attention_bridge_optimizer(model, task_queue_manager, base_optimizer):
                 optimizer = base_optimizer(params)
                 suboptimizers[name] = optimizer
 
-    for generator_id in task_queue_manager.get_generators():
+    for generator_id in task_queue_manager.get_my_generators():
         generator = model.generator[f'generator_{generator_id}']
         params = []
         for name, param in generator.named_parameters():

--- a/mammoth/utils/parse.py
+++ b/mammoth/utils/parse.py
@@ -111,6 +111,7 @@ class DataOptsCheckerMixin(object):
             node_gpu = corpus.get('node_gpu', None)
             if node_gpu is not None:
                 assert RE_NODE_GPU.match(node_gpu)
+            else:
                 n_without_node_gpu += 1
             src_tgt = corpus.get('src_tgt', None)
             assert src_tgt is not None
@@ -139,7 +140,8 @@ class DataOptsCheckerMixin(object):
                     logger.warning(f'offset {offset} stride {stride} is probably not what you want')
 
         # Either all tasks should be assigned to a gpu, or none
-        assert n_without_node_gpu == 0 or n_without_node_gpu == len(corpora)
+        assert n_without_node_gpu == 0 or n_without_node_gpu == len(corpora), \
+            f'n_without_node_gpu: {n_without_node_gpu} not in {{ 0, {len(corpora)} }}'
 
         logger.info(f"Parsed {len(corpora)} corpora from -data.")
         opts.tasks = corpora

--- a/mammoth/utils/report_manager.py
+++ b/mammoth/utils/report_manager.py
@@ -59,7 +59,7 @@ class ReportMgrBase(object):
         patience,
         report_stats,
         multigpu=False,
-        sampled_task_count=None,
+        sampled_task_counts=None,
     ):
         """
         This is the user-defined batch-level traing progress
@@ -89,7 +89,7 @@ class ReportMgrBase(object):
                 learning_rate,
                 patience,
                 report_stats,
-                sampled_task_count=sampled_task_count
+                sampled_task_counts=sampled_task_counts
             )
             return mammoth.utils.Statistics()
         else:
@@ -145,7 +145,7 @@ class ReportMgr(ReportMgrBase):
         if self.tensorboard_writer is not None:
             stats.log_tensorboard(prefix, self.tensorboard_writer, learning_rate, patience, step)
 
-    def _report_training(self, step, num_steps, learning_rate, patience, report_stats, sampled_task_count):
+    def _report_training(self, step, num_steps, learning_rate, patience, report_stats, sampled_task_counts):
         """
         See base class method `ReportMgrBase.report_training`.
         """
@@ -154,9 +154,9 @@ class ReportMgr(ReportMgrBase):
         self.maybe_log_tensorboard(report_stats, "progress", learning_rate, patience, step)
         report_stats = mammoth.utils.Statistics()
 
-        total = sum(sampled_task_count.values())
+        total = sum(sampled_task_counts.values())
         logger.info(f'Task sampling distribution: (total {total})')
-        for task, count in sampled_task_count.most_common():
+        for task, count in sampled_task_counts.most_common():
             logger.info(f'Task: {task}\tcount: {count}\t{100 * count / total} %')
 
         return report_stats

--- a/tools/config_config.py
+++ b/tools/config_config.py
@@ -321,6 +321,9 @@ def corpora_schedule(opts):
         if use_weight:
             multiplier = ae_weight if src_lang == tgt_lang else 1.0
             corpus['weight'] = weight * multiplier
+        else:
+            # Log spam if weight is unset
+            corpus['weight'] = 1
         if use_introduce_at_training_step:
             # TODO: ensure this default always matches with opts.py
             total_steps = opts.in_config[0].get('train_steps', 100_000)
@@ -333,6 +336,9 @@ def corpora_schedule(opts):
                 introduce_at_training_step = round(total_steps * (1 - weight))
             corpus['introduce_at_training_step'] = introduce_at_training_step
             min_introduce_at_training_step = min(min_introduce_at_training_step, introduce_at_training_step)
+        else:
+            # Log spam if introduce_at_training_step is unset
+            corpus['introduce_at_training_step'] = 0
     if use_introduce_at_training_step and min_introduce_at_training_step > 0:
         # With a single very large task that gets split, it is possible that no task can start
         for cname, corpus in opts.in_config[0]['tasks'].items():


### PR DESCRIPTION
Tasks (corpus ids) are now sampled in a deterministic way such that all TaskQueueManagers can be aware of which task all other devices are training.

One benefit is that it is no longer necessary to communicate ready_t during gradient sync. This simplifies the algorithm, but does not seem to have any performance impact.

The PR includes refactoring of multiple locations in the code to use a joint representation of DistributedComponents, to determine which parameters are on which devices, and how they need to be communicated.
- broadcast of initial model parameters
- gradient communication during training
- optimizer

There are additional places that could be refactored in future work:
- model_builder
- module splitter

This PR also includes a SimpleLookAheadBucketing, which provides dynamic minibatching with guarantees on the maximum batch size. This allows increasing the minibatch size without causing VRAM OOM.