### PR TITLE
Post-merge fixes to global sample corpus ids

### DIFF
--- a/mammoth/distributed/__init__.py
+++ b/mammoth/distributed/__init__.py
@@ -4,7 +4,7 @@ from mammoth.distributed.communication import (
     batch_producer,
     consumer,
     broadcast_tensors,
-    managed_reduce_and_rescale_grads,
+    externally_managed_reduce_and_rescale_grads,
     ErrorHandler,
 )
 from mammoth.distributed.contexts import DeviceContext, WorldContext, DeviceContextEnum
@@ -20,7 +20,7 @@ __all__ = [
     "batch_producer",
     "broadcast_tensors",
     "consumer",
-    "managed_reduce_and_rescale_grads",
+    "externally_managed_reduce_and_rescale_grads",
     "ErrorHandler",
     "DeviceContext",
     "WorldContext",

--- a/mammoth/distributed/communication.py
+++ b/mammoth/distributed/communication.py
@@ -36,7 +36,7 @@ def broadcast_tensors(tensors, src=0, group=None):
             torch.distributed.broadcast(t, src, group=group)
 
 
-def managed_reduce_and_rescale_grads(
+def externally_managed_reduce_and_rescale_grads(
     named_parameters,
     has_local_gradient: bool,
     gradient_norm: int,

--- a/mammoth/opts.py
+++ b/mammoth/opts.py
@@ -278,6 +278,13 @@ def model_opts(parser):
 
     # Encoder-Decoder Options
     group = parser.add_argument_group('Model- Encoder-Decoder')
+    group.add(
+        '--model_type',
+        '-model_type',
+        default='text',
+        choices=['text'],
+        help="Type of source model to use. Allows the system to incorporate non-text inputs. Options are [text].",
+    )
     group.add('--model_dtype', '-model_dtype', default='fp32', choices=['fp32', 'fp16'], help='Data type of the model.')
 
     group.add(
@@ -627,22 +634,23 @@ def _add_train_general_opts(parser):
         "uses more memory. Set to 0 to disable.",
     )
     group.add(
-        "-pool_size",
-        "--pool_size",
-        type=int,
-        default=2048,
-        help="(Maximum) number of examples to dynamically pool before batching.",
-    )
-    group.add(
-        "-n_buckets",
-        "--n_buckets",
+        "-lookahead_minibatches",
+        "--lookahead_minibatches",
         type=int,
         default=4,
-        help="The number of minibatches that will be yielded once bucketing is complete. "
+        help="The number of minibatches that SimpleLookAheadBucketing will read into a maxibatch, "
+        "pessimisticly sort by length, split into minibatches, and yield in one go. "
         "Recommended value: same as accum_count, or at least a multiple of it."
     )
+    group.add(
+        "-max_look_ahead_sentences",
+        "--max_look_ahead_sentences",
+        type=int,
+        default=2048,
+        help="(Maximum) number of sentence pairs that SimpleLookAheadBucketing can attempt to add to the maxibatch. "
+        "This is mainly a failsafe in case some corpus contains very short examples.",
+    )
 
-    group = parser.add_argument_group('Optimization')
     group.add(
         '--optim',
         '-optim',

--- a/mammoth/tests/test_look_ahead_bucketing.py
+++ b/mammoth/tests/test_look_ahead_bucketing.py
@@ -1,6 +1,6 @@
+import pytest
 from itertools import product
 
-import unittest
 from mammoth.inputters.dataloader import build_dataloader
 
 
@@ -26,37 +26,48 @@ class MockStream():
         return items
 
 
-class TestLookAheadBucketing(unittest.TestCase):
-
-    def test_all_read(self):
-        max_batch_size = 12
-        stream = MockStream([
-            hashabledict({
-                'src': tuple([letter for _ in range(i)]),
-                'tgt': tuple([letter for _ in range(j)]),
-            })
-            for letter in 'xyz'
-            for i, j in product(range(1, 11), range(1, 11))
-        ])
-        lab = build_dataloader(
-            stream,
-            batch_size=max_batch_size,
-            batch_type='tokens',
-            pool_size=4,
-            n_buckets=4,
-            cycle=True,
-            as_iter=False
-        )
-        examples_read = []
-        batches = iter(lab)
-        for _ in range(1000):
-            batch = next(batches)
-            assert len(batch) > 0
-            src_toks = sum(len(ex['src']) for ex in batch)
-            tgt_toks = sum(len(ex['tgt']) for ex in batch)
-            # check that the batch size is respected
-            assert src_toks <= max_batch_size
-            assert tgt_toks <= max_batch_size, str(batch)
-            examples_read.extend(batch)
-        # Check that the stream was cycled
-        self.assertTrue(len(examples_read) > len(stream))
+@pytest.mark.parametrize(
+    ('max_batch_size', 'lookahead_minibatches'),
+    [
+        (12, 4),
+        (13, 4),
+        (14, 4),
+        (15, 4),
+        (12, 5),
+        (13, 5),
+        (14, 5),
+        (15, 5),
+    ],
+)
+def test_simple_lookeahead_bucketing(max_batch_size, lookahead_minibatches):
+    stream = MockStream([
+        hashabledict({
+            'src': tuple([letter for _ in range(i)]),
+            'tgt': tuple([letter for _ in range(j)]),
+        })
+        for letter in 'xyz'
+        for i, j in product(range(1, 11), range(1, 11))
+    ])
+    lab = build_dataloader(
+        stream,
+        batch_size=max_batch_size,
+        batch_type='tokens',
+        max_look_ahead_sentences=512,
+        lookahead_minibatches=lookahead_minibatches,
+        cycle=True,
+        as_iter=False
+    )
+    examples_read = []
+    batches = iter(lab)
+    for _ in range(1000):
+        batch = next(batches)
+        print(batch)
+        assert len(batch) > 0
+        src_toks = sum(len(ex['src']) for ex in batch)
+        tgt_toks = sum(len(ex['tgt']) for ex in batch)
+        # check that the batch size is respected
+        assert src_toks <= max_batch_size
+        assert tgt_toks <= max_batch_size, str(batch)
+        examples_read.extend(batch)
+    # Check that the stream was cycled
+    assert len(examples_read) > len(stream)

--- a/mammoth/train_single.py
+++ b/mammoth/train_single.py
@@ -101,7 +101,9 @@ def main(
     transforms_cls = get_transforms_cls(opts._all_transform)
     model_opts = _get_model_opts(opts, checkpoint=checkpoint)
 
-    task_queue_manager.create_all_distributed_components(use_attention_bridge=model_opts.bridge)
+    task_queue_manager.create_all_distributed_components(
+        use_attention_bridge=(model_opts.ab_layers is not None and len(model_opts.ab_layers) != 0),
+    )
 
     # Build model.
 

--- a/mammoth/trainer.py
+++ b/mammoth/trainer.py
@@ -278,7 +278,7 @@ class Trainer(object):
                     continue
                 # logger.warning(f'Syncing {component.get_name()}')   # DEBUG
                 params = component.named_parameters(self.model)
-                mammoth.distributed.managed_reduce_and_rescale_grads(
+                mammoth.distributed.externally_managed_reduce_and_rescale_grads(
                     named_parameters=params,
                     has_local_gradient=gradient_sync.has_local_gradient,
                     gradient_norm=gradient_sync.gradient_norm,
@@ -288,7 +288,7 @@ class Trainer(object):
             self._maybe_update_stats_from_parameters(report_stats, self.model.named_parameters())
 
             # Including single-device components
-            self.optim.managed_step(gradient_syncs)
+            self.optim.externally_managed_step(gradient_syncs)
             self.optim.zero_grad()
 
             if step % 1000 == 0 and step > 0:

--- a/mammoth/translate/translator.py
+++ b/mammoth/translate/translator.py
@@ -479,8 +479,8 @@ class Inference(object):
             corpus,
             batch_size=batch_size,
             batch_type=batch_type,
-            pool_size=512,
-            n_buckets=512,
+            max_look_ahead_sentences=512,
+            lookahead_minibatches=512,
             cycle=False,
         )
 

--- a/mammoth/utils/optimizers.py
+++ b/mammoth/utils/optimizers.py
@@ -202,7 +202,7 @@ class MultipleOptimizer(object):
         for name in self.optimizers:
             self.optimizers[name].zero_grad()
 
-    def managed_step(self, gradient_syncs, grad_scaler=None):
+    def externally_managed_step(self, gradient_syncs, grad_scaler=None):
         """Step through only the trained suboptimizers"""
         trained_components = {
             gradient_sync.component.get_name() for gradient_sync in gradient_syncs
@@ -387,7 +387,7 @@ class Optimizer(object):
         else:
             loss.backward()
 
-    def managed_step(self, *args, **kwargs):
+    def externally_managed_step(self, *args, **kwargs):
         """Update the model parameters based on current gradients.
 
         Optionally, will employ gradient modification or update learning
@@ -415,7 +415,7 @@ class Optimizer(object):
             # Updates the scale for next iteration.
             self._scaler.update()
         else:
-            self._optimizer.managed_step(*args, **kwargs)
+            self._optimizer.externally_managed_step(*args, **kwargs)
         self._decay_step += 1
         self._training_step += 1
 

--- a/tools/config_config.py
+++ b/tools/config_config.py
@@ -287,9 +287,9 @@ def corpora_schedule(opts):
     corpora_lens_cache = read_cached_linecounts(corpora_lens_cache_file)
     logger.info('cached corpora_lens:')
     for path, len in corpora_lens_cache.items():
-        logger.info(f'{path}:\t{len}')
+        logger.info(f'CACHED:\t{path}:\t{len}')
     corpora_lens = {}
-    for cname, corpus in opts.in_config[0]['tasks'].items():
+    for cname, corpus in sorted(opts.in_config[0]['tasks'].items(), key=lambda x: x[0]):
         if corpus['path_src'] in corpora_lens_cache:
             length = corpora_lens_cache[corpus['path_src']]
             corpora_lens[cname] = length
@@ -298,7 +298,7 @@ def corpora_schedule(opts):
             corpora_lens[cname] = length
             with open(corpora_lens_cache_file, 'a') as cache_out:
                 print(f'{length}\t{corpus["path_src"]}', file=cache_out)
-                logger.info(f'{length}\t{corpus["path_src"]}')
+                logger.info(f'NEW:\t{corpus["path_src"]}\t{length}')
     logger.info('final corpora_lens:')
     for cname, len in corpora_lens.items():
         logger.info(f'{cname}:\t{len}')


### PR DESCRIPTION
Post-merge fixes based on comments to PR #66 and testing.

- Rename `managed_*` to `externally_managed_*`. Hopefully this describes it a bit better.
- Due to a rounding bug in the bucketing, it was possible for the minibatch size guarantee to be exceeded even when using more than one sentence per minibatch. The estimate is now more conservative, and exceeding the limit should now only occur if minibatches are very small compared to the sentence lengths.
- Very minor unrelated logging improvement to config-config