### PR TITLE
Reimplement fixed size batching

### DIFF
--- a/mammoth/modules/layer_stack_encoder.py
+++ b/mammoth/modules/layer_stack_encoder.py
@@ -8,13 +8,14 @@ from mammoth.distributed import DatasetMetadata
 
 
 class LayerStackEncoder(EncoderBase):
-    def __init__(self, embeddings, encoders):
+    def __init__(self, embeddings, encoders, max_length=None):
         super().__init__()
 
         self.embeddings = embeddings
         self.encoders: nn.ModuleList[nn.ModuleDict] = encoders
         self._adapter_to_stack: Dict[str, int] = dict()
         self._active: List[str] = []
+        self._max_length = max_length
 
     @classmethod
     def from_opts(cls, opts, embeddings, task_queue_manager):
@@ -48,7 +49,7 @@ class LayerStackEncoder(EncoderBase):
                     is_normformer=opts.normformer,
                 )
             encoders.append(stacks)
-        return cls(embeddings, encoders)
+        return cls(embeddings, encoders, opts.max_length)
 
     @classmethod
     def from_trans_opt(cls, opts, embeddings, task):
@@ -79,7 +80,7 @@ class LayerStackEncoder(EncoderBase):
                 is_normformer=opts.normformer,
             )
             encoders.append(stacks)
-        return cls(embeddings, encoders)
+        return cls(embeddings, encoders, max_length=None)
 
     def update_dropout(self, dropout, attention_dropout):
         self.embeddings.update_dropout(dropout)
@@ -91,7 +92,7 @@ class LayerStackEncoder(EncoderBase):
         # wrapper embeds src and creates mask
         emb = self.embeddings(src)
         emb = emb.transpose(0, 1).contiguous()
-        mask = ~sequence_mask(lengths).unsqueeze(1)
+        mask = ~sequence_mask(lengths, max_len=self._max_length).unsqueeze(1)
 
         output = emb
         for active_id, stacks in zip(self._active, self.encoders):
@@ -144,7 +145,7 @@ class LayerStackEncoder(EncoderBase):
         self._adapter_to_stack[name] = layer_stack_index
         if layer_stack_index >= len(self.encoders):
             raise ValueError(
-                f'No layer stack with index {layer_stack_index}. There are {len(len(self.encoders))} layer stacks'
+                f'No layer stack with index {layer_stack_index}. There are {len(self.encoders)} layer stacks'
             )
         if len(module_ids) == 0:
             raise Exception(f'Adapter {adapter_group} {sub_id} has no module_ids')

--- a/mammoth/opts.py
+++ b/mammoth/opts.py
@@ -617,6 +617,8 @@ def _add_train_general_opts(parser):
         choices=["sents", "tokens"],
         help="Batch grouping for batch_size. Standard is sents. Tokens will do dynamic batching",
     )
+    group.add('--pad_to_max_length', '-pad_to_max_length', action='store_true')
+    group.add('--max_length', '-max_length', type=int, default=None, help='Maximum sequence length.')
     group.add(
         '--task_distribution_strategy',
         '-task_distribution_strategy',

--- a/mammoth/opts.py
+++ b/mammoth/opts.py
@@ -617,7 +617,13 @@ def _add_train_general_opts(parser):
         choices=["sents", "tokens"],
         help="Batch grouping for batch_size. Standard is sents. Tokens will do dynamic batching",
     )
-    group.add('--pad_to_max_length', '-pad_to_max_length', action='store_true')
+    group.add(
+        '--pad_to_max_length',
+        '-pad_to_max_length',
+        action='store_true',
+        help='Pad all minibatches to max_length instead of to the length of the longest sequence in the minibatch. '
+        'Using this together with batch_type=sents results in tensors of a fixed shape.'
+    )
     group.add('--max_length', '-max_length', type=int, default=None, help='Maximum sequence length.')
     group.add(
         '--task_distribution_strategy',

--- a/mammoth/tests/test_look_ahead_bucketing.py
+++ b/mammoth/tests/test_look_ahead_bucketing.py
@@ -71,3 +71,34 @@ def test_simple_lookeahead_bucketing(max_batch_size, lookahead_minibatches):
         examples_read.extend(batch)
     # Check that the stream was cycled
     assert len(examples_read) > len(stream)
+
+
+@pytest.mark.parametrize(
+    'batch_size',
+    [1, 5, 12, 2048],
+)
+def test_sentence_minibatcher(batch_size):
+    stream = MockStream([
+        hashabledict({
+            'src': tuple([letter for _ in range(i)]),
+            'tgt': tuple([letter for _ in range(j)]),
+        })
+        for letter in 'xyz'
+        for i, j in product(range(1, 11), range(1, 11))
+    ])
+    lab = build_dataloader(
+        stream,
+        batch_size=batch_size,
+        batch_type='sents',
+        cycle=True,
+        as_iter=False
+    )
+    examples_read = []
+    batches = iter(lab)
+    for _ in range(1000):
+        batch = next(batches)
+        print(batch)
+        assert len(batch) == batch_size
+        examples_read.extend(batch)
+    # Check that the stream was cycled
+    assert len(examples_read) > len(stream)


### PR DESCRIPTION
Fixed size batching entails using
- "batch_type: sents" to fix the batch dimension to batch_size, and
- "pad_to_max_length: true" together with "max_length" to fix the sequence length dimension.

This feature was first implemented in #55 on top of the spiral LookAheadBucketing, which was removed in https://github.com/Helsinki-NLP/mammoth/pull/66. Here it has been reimplemented as a standalone component.

Closes #67