### PR TITLE
Fix conflict between fp16 and deterministic sampling

### DIFF
--- a/mammoth/__init__.py
+++ b/mammoth/__init__.py
@@ -1,22 +1,14 @@
 """ Main entry point of the Mammoth library """
-import mammoth.inputters
-import mammoth.models
-import mammoth.utils
-import mammoth.modules
-import mammoth.opts
 from mammoth.trainer import Trainer
-import sys
-import mammoth.utils.optimizers
+from mammoth.utils import optimizers
 
-mammoth.utils.optimizers.Optim = mammoth.utils.optimizers.Optimizer
-sys.modules["mammoth.Optim"] = mammoth.utils.optimizers
+# FIXME: what is the purpose of this hack?
+# import sys
+# mammoth.utils.optimizers.Optim = mammoth.utils.optimizers.Optimizer
+# sys.modules["mammoth.Optim"] = mammoth.utils.optimizers
 
 __all__ = [
-    mammoth.inputters,
-    mammoth.models,
-    mammoth.utils,
-    mammoth.modules,
-    mammoth.opts,
+    "optimizers",
     "Trainer"
 ]
 

--- a/mammoth/train_single.py
+++ b/mammoth/train_single.py
@@ -4,7 +4,7 @@ import torch
 import time
 
 from mammoth.model_builder import build_model
-from mammoth.utils.optimizers import Optimizer
+from mammoth.utils.optimizers import MultipleOptimizer
 from mammoth.utils.misc import set_random_seed
 from mammoth.trainer import build_trainer
 from mammoth.models import build_model_saver
@@ -119,7 +119,7 @@ def main(
 
     # Build optimizer.
     logger.info("{} - Build optimizer".format(device_context.id))
-    optim = Optimizer.from_opts(
+    optim = MultipleOptimizer.from_opts(
         model,
         opts,
         task_queue_manager=task_queue_manager,

--- a/mammoth/utils/__init__.py
+++ b/mammoth/utils/__init__.py
@@ -3,7 +3,7 @@ from mammoth.utils.misc import split_corpus, aeq, use_gpu, set_random_seed
 from mammoth.utils.alignment import make_batch_align_matrix
 from mammoth.utils.report_manager import ReportMgr, build_report_manager
 from mammoth.utils.statistics import Statistics
-from mammoth.utils.optimizers import MultipleOptimizer, Optimizer, AdaFactorFairSeq
+from mammoth.utils.optimizers import MultipleOptimizer
 from mammoth.utils.earlystopping import EarlyStopping, scorers_from_opts
 from mammoth.utils.loss import build_loss_compute
 
@@ -16,8 +16,6 @@ __all__ = [
     "build_report_manager",
     "Statistics",
     "MultipleOptimizer",
-    "Optimizer",
-    "AdaFactorFairSeq",
     "EarlyStopping",
     "scorers_from_opts",
     "make_batch_align_matrix",

--- a/mammoth/utils/optimizers.py
+++ b/mammoth/utils/optimizers.py
@@ -1,13 +1,10 @@
 """ Optimizers class """
 import functools
-import importlib
 import math
 import torch
 import torch.optim as optim
-import types
 from collections import Counter
 from math import sqrt
-from mammoth.utils.misc import fn_args
 from torch.nn.utils import clip_grad_norm_
 from mammoth.utils.logging import logger
 
@@ -170,11 +167,10 @@ def linear_warmup_decay(step, warmup_steps, rate, train_steps):
 
 
 class MultipleOptimizer(object):
-    """Implement multiple optimizers"""
+    """Separate optimizers for each distributed component"""
 
-    def __init__(self, op, multiOptims_Langs=None):
+    def __init__(self, op):
         self.optimizers = op
-        self.multiOptims_Langs = multiOptims_Langs
         self._steps = Counter()
 
     @property
@@ -212,7 +208,6 @@ class MultipleOptimizer(object):
         """Returns the state dictionary"""
         return {
             'optimizers': {k: v.state_dict() for k, v in self.optimizers.items()},
-            'multiOptims_Langs': self.multiOptims_Langs,
             'steps': self._steps,
         }
 
@@ -231,7 +226,6 @@ class MultipleOptimizer(object):
         else:
             logger.info("Some components do not match. Do not load optimizer from checkpoint.")
 
-        self.multiOptims_Langs = state_dict["multiOptims_Langs"]
         self._steps = state_dict["steps"]
 
 

--- a/mammoth/utils/optimizers.py
+++ b/mammoth/utils/optimizers.py
@@ -91,18 +91,6 @@ def build_torch_optimizer(model, opts, task_queue_manager):
         )
     elif opts.optim == 'fusedadam':
         raise NotImplementedError()
-        # # we use here a FusedAdam() copy of an old Apex repo
-        # optimizer = FusedAdam(params, lr=opts.learning_rate, betas=betas)
-        # if opts.model_dtype == 'fp16':
-        #     import apex
-
-        #     # In this case use the old FusedAdam with FP16_optimizer wrapper
-        #     static_loss_scale = opts.loss_scale
-        #     dynamic_loss_scale = opts.loss_scale == 0
-        #     base_optimizer = functools.partial(
-        #         apex.contrib.optimizers.FP16_Optimizer
-        #         optimizer, static_loss_scale=static_loss_scale, dynamic_loss_scale=dynamic_loss_scale
-        #     )
     else:
         raise ValueError('Invalid optimizer type: ' + opts.optim)
 
@@ -326,13 +314,10 @@ class Optimizer(object):
         )
 
         if opts.model_dtype == "fp16":
-            if opts.optim == "fusedadam":
-                optimizer._fp16 = "legacy"
-            else:
-                optimizer._fp16 = "amp"
-                from torch.cuda.amp import GradScaler
+            optimizer._fp16 = "amp"
+            from torch.cuda.amp import GradScaler
 
-                optimizer._scaler = GradScaler()
+            optimizer._scaler = GradScaler()
 
         if optim_state_dict:
             optimizer.load_state_dict(optim_state_dict)
@@ -379,11 +364,6 @@ class Optimizer(object):
         backward pass."""
         if self.amp:
             self._scaler.scale(loss).backward()
-        elif self._fp16 == "legacy":
-            kwargs = {}
-            if "update_master_grads" in fn_args(self._optimizer.backward):
-                kwargs["update_master_grads"] = True
-            self._optimizer.backward(loss, **kwargs)
         else:
             loss.backward()
 
@@ -398,15 +378,10 @@ class Optimizer(object):
         if self.amp:
             for suboptimizer in self._optimizer.optimizers.values():
                 self._scaler.unscale_(suboptimizer)
-        elif self._fp16 == "legacy":
-            if hasattr(self._optimizer, "update_master_grads"):
-                self._optimizer.update_master_grads()
-            if hasattr(self._optimizer, "clip_master_grads") and self._max_grad_norm > 0:
-                self._optimizer.clip_master_grads(self._max_grad_norm)
 
         for group in self._optimizer.param_groups:
             group['lr'] = learning_rate
-            if self._max_grad_norm > 0 and self._fp16 != "legacy":
+            if self._max_grad_norm > 0:
                 clip_grad_norm_(group['params'], self._max_grad_norm)
 
         if self.amp:
@@ -593,168 +568,6 @@ class AdaFactor(torch.optim.Optimizer):
 
         return loss
 """
-
-
-class FusedAdam(torch.optim.Optimizer):
-
-    """Implements Adam algorithm. Currently GPU-only.
-       Requires Apex to be installed via
-    ``python setup.py install --cuda_ext --cpp_ext``.
-    It has been proposed in `Adam: A Method for Stochastic Optimization`_.
-    Arguments:
-        params (iterable): iterable of parameters to optimize or dicts defining
-            parameter groups.
-        lr (float, optional): learning rate. (default: 1e-3)
-        betas (Tuple[float, float], optional): coefficients used for computing
-            running averages of gradient and its square.
-            (default: (0.9, 0.999))
-        eps (float, optional): term added to the denominator to improve
-            numerical stability. (default: 1e-8)
-        weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
-        amsgrad (boolean, optional): whether to use the AMSGrad variant of this
-            algorithm from the paper `On the Convergence of Adam and Beyond`_
-            (default: False) NOT SUPPORTED in FusedAdam!
-        eps_inside_sqrt (boolean, optional): in the 'update parameters' step,
-            adds eps to the bias-corrected second moment estimate before
-            evaluating square root instead of adding it to the square root of
-            second moment estimate as in the original paper. (default: False)
-    .. _Adam: A Method for Stochastic Optimization:
-        https://arxiv.org/abs/1412.6980
-    .. _On the Convergence of Adam and Beyond:
-        https://openreview.net/forum?id=ryQu7f-RZ
-    """
-
-    def __init__(
-        self,
-        params,
-        lr=1e-3,
-        bias_correction=True,
-        betas=(0.9, 0.999),
-        eps=1e-8,
-        eps_inside_sqrt=False,
-        weight_decay=0.0,
-        max_grad_norm=0.0,
-        amsgrad=False,
-    ):
-        global fused_adam_cuda
-        fused_adam_cuda = importlib.import_module("fused_adam_cuda")
-
-        if amsgrad:
-            raise RuntimeError('AMSGrad variant not supported.')
-        defaults = dict(
-            lr=lr,
-            bias_correction=bias_correction,
-            betas=betas,
-            eps=eps,
-            weight_decay=weight_decay,
-            max_grad_norm=max_grad_norm,
-        )
-        super(FusedAdam, self).__init__(params, defaults)
-        self.eps_mode = 0 if eps_inside_sqrt else 1
-
-    def step(self, closure=None, grads=None, output_params=None, scale=1.0, grad_norms=None):
-        """Performs a single optimization step.
-        Arguments:
-            closure (callable, optional): A closure that reevaluates the model
-                and returns the loss.
-            grads (list of tensors, optional): weight gradient to use for the
-                optimizer update. If gradients have type torch.half, parameters
-                are expected to be in type torch.float. (default: None)
-            output params (list of tensors, optional): A reduced precision copy
-                of the updated weights written out in addition to the regular
-                updated weights. Have to be of same type as gradients.
-                (default: None)
-            scale (float, optional): factor to divide gradient tensor values
-                by before applying to weights. (default: 1)
-        """
-        loss = None
-        if closure is not None:
-            loss = closure()
-
-        if grads is None:
-            grads_group = [None] * len(self.param_groups)
-        # backward compatibility
-        # assuming a list/generator of parameter means single group
-        elif isinstance(grads, types.GeneratorType):
-            grads_group = [grads]
-        elif not isinstance(grads[0], list):
-            grads_group = [grads]
-        else:
-            grads_group = grads
-
-        if output_params is None:
-            output_params_group = [None] * len(self.param_groups)
-        elif isinstance(output_params, types.GeneratorType):
-            output_params_group = [output_params]
-        elif not isinstance(output_params[0], list):
-            output_params_group = [output_params]
-        else:
-            output_params_group = output_params
-
-        if grad_norms is None:
-            grad_norms = [None] * len(self.param_groups)
-
-        for group, grads_this_group, output_params_this_group, grad_norm in zip(
-            self.param_groups, grads_group, output_params_group, grad_norms
-        ):
-            if grads_this_group is None:
-                grads_this_group = [None] * len(group['params'])
-            if output_params_this_group is None:
-                output_params_this_group = [None] * len(group['params'])
-
-            # compute combined scale factor for this group
-            combined_scale = scale
-            if group['max_grad_norm'] > 0:
-                # norm is in fact norm*scale
-                clip = ((grad_norm / scale) + 1e-6) / group['max_grad_norm']
-                if clip > 1:
-                    combined_scale = clip * scale
-
-            bias_correction = 1 if group['bias_correction'] else 0
-
-            for p, grad, output_param in zip(group['params'], grads_this_group, output_params_this_group):
-                # note: p.grad should not ever be set for correct operation of
-                # mixed precision optimizer that sometimes sends None gradients
-                if p.grad is None and grad is None:
-                    continue
-                if grad is None:
-                    grad = p.grad.data
-                if grad.is_sparse:
-                    raise RuntimeError('sparse gradient not supported')
-
-                state = self.state[p]
-
-                # State initialization
-                if len(state) == 0:
-                    state['step'] = 0
-                    # Exponential moving average of gradient values
-                    state['exp_avg'] = torch.zeros_like(p.data)
-                    # Exponential moving average of squared gradient values
-                    state['exp_avg_sq'] = torch.zeros_like(p.data)
-
-                exp_avg, exp_avg_sq = state['exp_avg'], state['exp_avg_sq']
-                beta1, beta2 = group['betas']
-
-                state['step'] += 1
-
-                out_p = torch.tensor([], dtype=torch.float) if output_param is None else output_param
-                fused_adam_cuda.adam(
-                    p.data,
-                    out_p,
-                    exp_avg,
-                    exp_avg_sq,
-                    grad,
-                    group['lr'],
-                    beta1,
-                    beta2,
-                    group['eps'],
-                    combined_scale,
-                    state['step'],
-                    self.eps_mode,
-                    bias_correction,
-                    group['weight_decay'],
-                )
-        return loss
 
 
 class AdaFactorFairSeq(torch.optim.Optimizer):

--- a/mammoth/utils/report_manager.py
+++ b/mammoth/utils/report_manager.py
@@ -60,6 +60,7 @@ class ReportMgrBase(object):
         report_stats,
         multigpu=False,
         sampled_task_counts=None,
+        optimizer=None,
     ):
         """
         This is the user-defined batch-level traing progress
@@ -91,6 +92,9 @@ class ReportMgrBase(object):
                 report_stats,
                 sampled_task_counts=sampled_task_counts
             )
+            if optimizer is not None:
+                for line in optimizer.report_steps():
+                    logger.info(line)
             return mammoth.utils.Statistics()
         else:
             return report_stats

--- a/mammoth/utils/statistics.py
+++ b/mammoth/utils/statistics.py
@@ -149,14 +149,14 @@ class Statistics(object):
         if num_steps > 0:
             step_fmt = "%s/%5d" % (step_fmt, num_steps)
         logger.info(
-            ("%s: Step %s; acc: %6.2f; ppl: %5.2f; xent: %4.2f; " + "lr: %7.5f; %3.0f/%3.0f tok/s; %6.0f sec")
+            ("%s: Step %s; acc: %6.2f; ppl: %5.2f; xent: %4.2f; %3.0f/%3.0f tok/s; %6.0f sec")
             % (
                 meta_str,
                 step_fmt,
                 self.accuracy(),
                 self.ppl(),
                 self.xent(),
-                learning_rate,
+                # learning_rate,    # was "lr: %7.5f;"
                 self.n_src_words / (t + 1e-5),
                 self.n_words / (t + 1e-5),
                 time.time() - start,
@@ -174,7 +174,7 @@ class Statistics(object):
         writer.add_scalar(prefix + "/ppl", self.ppl(), step)
         writer.add_scalar(prefix + "/accuracy", self.accuracy(), step)
         writer.add_scalar(prefix + "/tgtper", self.n_words / t, step)
-        writer.add_scalar(prefix + "/lr", learning_rate, step)
+        # writer.add_scalar(prefix + "/lr", learning_rate, step)
         if patience is not None:
             writer.add_scalar(prefix + "/patience", patience, step)
 


### PR DESCRIPTION
    Fix conflict between fp16 and deterministic sampling

    Due to the removal of the grad hook, MultipleOptimizer no longer has a
    method step, it has been replaced with externally_managed_step which
    takes information about which optimizers need to be stepped. This means
    that it is no longer compatible with torch.cuda.amp.GradScaler.

    While fixing this issue, the MultipleOptimizer system was also
    refactored.
    - MultipleOptimizer and the OpenNMT Optimizer wrapper switched places:
      MultipleOptimizer now wraps the other one, instead of the reverse.
    - The OpenNMT Optimizer was renamed to SubOptimizer for clarity.
    - SubOptimizer handles learning rate scheduling and grad clipping.
    - MultipleOptimizer handles creation of multiple optimizers, grad scaling,
      restoring from checkpoint, backward, zero_grad, deciding which
      suboptimizers to step, and reporting.
    - Each optimizer now individually controls its learning rate schedule.
      When new components with freshly initialized parameters are introduced
      by the curriculum, they now apply warmup to the LR of these
      parameters. This should improve stability.
    - As each optimizer has its own learning rate, it is not obvious what to
      log in the report_training one-liner. Learning rate was removed.
      Instead, all optimizers log their learning rates. This is currently
      log spam, but will be lowered to debug in #70.

    Note that each sub-optimizer having its own GradScaler leads to multiple backward
    passes and RuntimeError. There can only be one GradScaler, which must
    therefore be the responsibility of MultipleOptimizer.

    Closes: #71