### PR TITLE
Fix bugs in adapter implementation

### DIFF
--- a/mammoth/distributed/components.py
+++ b/mammoth/distributed/components.py
@@ -119,7 +119,7 @@ class DistributedTransformerWrapper(DistributedComponent, ABC):
         module = self.get_module(model)
         destination: Dict[str, Any] = OrderedDict()
         for name, sub_module in module._modules.items():
-            if name.endswith('attn_layers'):
+            if name in {'attn_layers', 'token_emb'}:
                 # stored separately
                 continue
             sub_module.state_dict(destination=destination, prefix=prefix + name + '.', keep_vars=keep_vars)
@@ -240,9 +240,9 @@ class DistributedAdapter(DistributedComponent):
 
     def get_module(self, model: NMTModel) -> nn.Module:
         if self.side == Side.encoder:
-            model.encoder.get_adapter(self.adapter_group, self.sub_id)
+            return model.encoder.get_adapter(f'adapter_{self.adapter_group}_{self.sub_id}')
         else:
-            model.decoder.get_adapter(self.adapter_group, self.sub_id)
+            return model.decoder.get_adapter(f'adapter_{self.adapter_group}_{self.sub_id}')
 
 
 @dataclass

--- a/mammoth/distributed/components.py
+++ b/mammoth/distributed/components.py
@@ -130,7 +130,7 @@ class DistributedTransformerWrapper(DistributedComponent, ABC):
         mismatch = module.load_state_dict(state_dict, strict=False)
         missing_keys = [
             name for name in mismatch.missing_keys
-            if not name.startswith('attn_layers.') or name.startswith('token_emb.')
+            if not any(name.startswith(prefix) for prefix in ('attn_layers.', 'token_emb.'))
         ]
         return mismatch._replace(missing_keys=missing_keys)
 

--- a/mammoth/modules/adapters.py
+++ b/mammoth/modules/adapters.py
@@ -77,8 +77,9 @@ class LoraAdapterLayer(nn.Module):
 
     def apply(self, tmp_layer_types, tmp_layer_structs, tmp_layer_dropouts):
         # LoraAdapterLayer wraps the existing feedforward. No norms are added.
-        tmp_layer_structs[0][1] = self.wrap(tmp_layer_structs[0][1])
-        return tmp_layer_types, tmp_layer_structs, tmp_layer_dropouts
+        new_layer_structs = [nn.ModuleList(x) for x in tmp_layer_structs]
+        new_layer_structs[0][1] = self.wrap(new_layer_structs[0][1])
+        return tmp_layer_types, new_layer_structs, tmp_layer_dropouts
 
     def wrap(self, base_layer):
         self.wrapped_base_layer = base_layer
@@ -201,7 +202,7 @@ class AdaptedAttentionLayers(AttentionLayers):
         ):
             if layer_type == 'f':
                 # Adapters apply to feedforward layers
-                adapter_layers = adapter_layers_by_index[i]
+                adapter_layers = adapter_layers_by_index[f'layer{i}']
                 tmp_layer_types = [layer_type]
                 tmp_layer_structs = [layer_struct]
                 tmp_layer_dropouts = [layer_dropout]

--- a/mammoth/modules/layer_stack.py
+++ b/mammoth/modules/layer_stack.py
@@ -3,7 +3,7 @@ from typing import List, Sequence, Optional, Tuple, Dict
 from x_transformers import TransformerWrapper
 from x_transformers.x_transformers import LayerIntermediates, TokenEmbedding
 
-from mammoth.modules.adapters import AdaptedAttentionLayers
+from mammoth.modules.adapters import AdaptedAttentionLayers, Adapter
 
 
 class AdaptedAttentionLayersStack(nn.Module):
@@ -65,11 +65,13 @@ class StackXcoder(nn.ModuleDict):
         transformer_wrappers: Dict[str, TransformerWrapper],
         attention_layer_blocks: Dict[int, Dict[str, AdaptedAttentionLayers]],
         token_embs: Dict[str, TokenEmbedding],
+        adapters: Optional[Dict[str, Adapter]],
     ):
         super().__init__(transformer_wrappers)
         self.attention_layers_by_xcoder_id: Dict[int, Dict[str, AdaptedAttentionLayers]] = attention_layer_blocks
         self.token_embs: Dict[str, TokenEmbedding] = token_embs
         self.active_task: Optional[str] = None
+        self.adapters = adapters
 
     # TransformerWrapper wraps an AttentionLayers in embeddings and some other functionality.
     # We use one TransformerWrapper per task.
@@ -95,5 +97,8 @@ class StackXcoder(nn.ModuleDict):
 
     def get_embedding_by_lang(self, lang):
         return self.token_embs[lang]
+
+    def get_adapter(self, adapter_name):
+        return self.adapters[adapter_name]
 
     # Lack of forward is intentional: call forward on the return value of activate

--- a/mammoth/train_single.py
+++ b/mammoth/train_single.py
@@ -131,7 +131,7 @@ def main(
         task_queue_manager=task_queue_manager,
         frame_checkpoint=frame_checkpoint,
     )
-    logger.info("{} - total optimizer parameters: {}".format(
+    logger.info("{} - total optimized parameters: {}".format(
         device_context.id,
         optim.count_parameters()
     ))

--- a/tools/config_config.py
+++ b/tools/config_config.py
@@ -618,36 +618,38 @@ def adapter_config(opts):
         if 'adapters' not in task_config:
             task_config['adapters'] = {'encoder': [], 'decoder': []}
     # TODO: refactor and add support for {SRC|TGT}_{LANGUAGE|GROUP} also to adapters
-    for adapter_name, adapter_config in sorted(encoder_adapters.items()):
-        if adapter_config['ids'] == 'LANGUAGE':
-            adapter_config['ids'] = list(src_langs)
-            for task_key, task_config in opts.in_config[0]['tasks'].items():
-                task_src, task_tgt = task_config['src_tgt'].split('-')
-                task_config['adapters']['encoder'].append([adapter_name, task_src])
-        elif adapter_config['ids'] == 'GROUP':
-            adapter_config['ids'] = list(src_groups)
-            for task_key, task_config in opts.in_config[0]['tasks'].items():
-                task_src, task_tgt = task_config['src_tgt'].split('-')
-                task_config['adapters']['encoder'].append([adapter_name, cc_opts['groups'][task_src]])
-        elif adapter_config['ids'] == 'FULL':
-            adapter_config['ids'] = ['full']
-            for task_key, task_config in opts.in_config[0]['tasks'].items():
-                task_config['adapters']['encoder'].append([adapter_name, 'full'])
-    for adapter_name, adapter_config in sorted(decoder_adapters.items()):
-        if adapter_config['ids'] == 'LANGUAGE':
-            adapter_config['ids'] = list(tgt_langs)
-            for task_key, task_config in opts.in_config[0]['tasks'].items():
-                task_src, task_tgt = task_config['src_tgt'].split('-')
-                task_config['adapters']['decoder'].append([adapter_name, task_tgt])
-        elif adapter_config['ids'] == 'GROUP':
-            adapter_config['ids'] = list(tgt_groups)
-            for task_key, task_config in opts.in_config[0]['tasks'].items():
-                task_src, task_tgt = task_config['src_tgt'].split('-')
-                task_config['adapters']['decoder'].append([adapter_name, cc_opts['groups'][task_tgt]])
-        elif adapter_config['ids'] == 'FULL':
-            adapter_config['ids'] = ['full']
-            for task_key, task_config in opts.in_config[0]['tasks'].items():
-                task_config['adapters']['decoder'].append([adapter_name, 'full'])
+    if len(encoder_adapters) > 0:
+        for adapter_name, adapter_config in sorted(encoder_adapters.items()):
+            if adapter_config['ids'] == 'LANGUAGE':
+                adapter_config['ids'] = list(src_langs)
+                for task_key, task_config in opts.in_config[0]['tasks'].items():
+                    task_src, task_tgt = task_config['src_tgt'].split('-')
+                    task_config['adapters']['encoder'].append([adapter_name, task_src])
+            elif adapter_config['ids'] == 'GROUP':
+                adapter_config['ids'] = list(src_groups)
+                for task_key, task_config in opts.in_config[0]['tasks'].items():
+                    task_src, task_tgt = task_config['src_tgt'].split('-')
+                    task_config['adapters']['encoder'].append([adapter_name, cc_opts['groups'][task_src]])
+            elif adapter_config['ids'] == 'FULL':
+                adapter_config['ids'] = ['full']
+                for task_key, task_config in opts.in_config[0]['tasks'].items():
+                    task_config['adapters']['encoder'].append([adapter_name, 'full'])
+    if len(decoder_adapters) > 0:
+        for adapter_name, adapter_config in sorted(decoder_adapters.items()):
+            if adapter_config['ids'] == 'LANGUAGE':
+                adapter_config['ids'] = list(tgt_langs)
+                for task_key, task_config in opts.in_config[0]['tasks'].items():
+                    task_src, task_tgt = task_config['src_tgt'].split('-')
+                    task_config['adapters']['decoder'].append([adapter_name, task_tgt])
+            elif adapter_config['ids'] == 'GROUP':
+                adapter_config['ids'] = list(tgt_groups)
+                for task_key, task_config in opts.in_config[0]['tasks'].items():
+                    task_src, task_tgt = task_config['src_tgt'].split('-')
+                    task_config['adapters']['decoder'].append([adapter_name, cc_opts['groups'][task_tgt]])
+            elif adapter_config['ids'] == 'FULL':
+                adapter_config['ids'] = ['full']
+                for task_key, task_config in opts.in_config[0]['tasks'].items():
+                    task_config['adapters']['decoder'].append([adapter_name, 'full'])
     opts.in_config[0]['adapters']['encoder'] = encoder_adapters
     opts.in_config[0]['adapters']['decoder'] = decoder_adapters
 


### PR DESCRIPTION
- Missing top-level adapter_type opt moved inside the adapter definition. This allows different types of adapter to coexist in a single model.
- Remove a level of looping to avoid redundant adapters.
- Accept an empty list to specify zero adapters for enc/dec (in addition to the empty dict which is more correct)
- Store adapters by name in StackXcoder