### PR TITLE
Unify the opt for using gpu

### DIFF
--- a/mammoth/opts.py
+++ b/mammoth/opts.py
@@ -903,7 +903,7 @@ def translate_opts(parser, dynamic=False):
     _add_logging_opts(parser, is_train=False)
 
     group = parser.add_argument_group('Efficiency')
-    group.add('--batch_size', '-batch_size', type=int, default=300, help='Batch size')
+    group.add('--batch_size', '-batch_size', type=int, default=200, help='Batch size')
     group.add(
         '--batch_type',
         '-batch_type',
@@ -911,7 +911,7 @@ def translate_opts(parser, dynamic=False):
         choices=["sents", "tokens"],
         help="Batch grouping for batch_size. Standard is tokens (max of src and tgt). Sents is unimplemented.",
     )
-    group.add('--gpu', '-gpu', type=int, default=-1, help="Device to run on")
+    group.add('--gpu_rank', '-gpu_rank', type=int, default=-1, help="Device to run on")
 
     group.add(
         "--output_model",

--- a/mammoth/translate/translation_server.py
+++ b/mammoth/translate/translation_server.py
@@ -119,7 +119,7 @@ class CTranslate2Translator(object):
 
         onmt_for_translator = {
             "device": "cuda" if opts.cuda else "cpu",
-            "device_index": opts.gpu if opts.cuda else 0,
+            "device_index": opts.gpu_rank if opts.cuda else 0,
         }
         for name, value in onmt_for_translator.items():
             setdefault_if_exists_must_match(ct2_translator_args, name, value)
@@ -417,7 +417,7 @@ class ServerModel(object):
         ArgumentParser.validate_prepare_opts(opts)
         ArgumentParser.validate_translate_opts(opts)
         ArgumentParser.validate_translate_opts_dynamic(opts)
-        opts.cuda = opts.gpu > -1
+        opts.cuda = opts.gpu_rank > -1
 
         sys.argv = prec_argv
         return opts
@@ -727,7 +727,7 @@ class ServerModel(object):
         if isinstance(self.translator, CTranslate2Translator):
             self.translator.to_gpu()
         else:
-            torch.cuda.set_device(self.opts.gpu)
+            torch.cuda.set_device(self.opts.gpu_rank)
             self.translator.model.cuda()
 
     def maybe_preprocess(self, sequence):

--- a/mammoth/translate/translator.py
+++ b/mammoth/translate/translator.py
@@ -28,7 +28,7 @@ def build_translator(opts, task_queue_manager, task, report_score=True, logger=N
     if out_file is None:
         outdir = os.path.dirname(opts.output)
         if outdir and not os.path.isdir(outdir):
-            warnings.warning(f'output file directory "{outdir}" does not exist... creating it.')
+            warnings.warn(f'output file directory "{outdir}" does not exist... creating it.')
             os.makedirs(os.path.dirname(opts.output), exist_ok=True)
         out_file = codecs.open(opts.output, "w+", "utf-8")
 
@@ -308,7 +308,7 @@ class Inference(object):
             vocabs,
             opts.src,
             tgt_file_path=opts.tgt,
-            gpu=opts.gpu,
+            gpu=opts.gpu_rank,
             n_best=opts.n_best,
             min_length=opts.min_length,
             max_length=opts.max_length,
@@ -831,6 +831,8 @@ class Translator(Inference):
             task_id=metadata.corpus_id,
             adapter_ids=metadata.decoder_adapter_ids,
         )
+        active_encoder.to(self._device)
+        active_decoder.to(self._device)
 
         # (2) Run the encoder on the src
         encoder_output, src_mask = self._run_encoder(active_encoder, batch)

--- a/mammoth/utils/misc.py
+++ b/mammoth/utils/misc.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
-import torch
-import random
+import gzip
 import inspect
 import numpy as np
-from itertools import islice, repeat
-from io import StringIO
 import os
+import random
+import torch
+from io import StringIO
+from itertools import islice, repeat
 
 
 def check_path(path, exist_ok=False, log=print):
@@ -33,7 +34,11 @@ def split_corpus(path, shard_size, default=None):
 def _split_corpus(path, shard_size):
     """Yield io's with `shard_size` lines each."""
     # FIXME: this is a horrible, ugly kludge
-    with open(path, "rt") as f:
+    if path.endswith('.gz'):
+        open_func = gzip.open
+    else:
+        open_func = open
+    with open_func(path, "rt") as f:
         if shard_size <= 0:
             yield f
         else:


### PR DESCRIPTION
Now both training and translation use `--gpu_rank 0`.
Previously the effective flag was different for training and translation, and using the wrong flag did not raise an error, just silently used cpu.

Closes #82